### PR TITLE
Add compatibility layer for BoolQuery clauses

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,10 @@ plugins {
 group = "com.github.silbaram"
 version = "1.0-SNAPSHOT"
 
+kotlin {
+    jvmToolchain(17)
+}
+
 repositories {
     mavenCentral()
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/BoolQueryExtensions.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/BoolQueryExtensions.kt
@@ -1,0 +1,41 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+
+/**
+ * Reflection based helper that invokes the appropriate BoolQuery.Builder method
+ * (e.g. `must`, `filter`, `mustNot`, `should`) regardless of whether the Java
+ * client expects a [List] or a vararg of [Query] instances.  This makes the DSL
+ * resilient to signature changes across different versions of the Elasticsearch
+ * Java client.
+ */
+internal fun BoolQuery.Builder.addClause(methodName: String, queries: List<Query>): BoolQuery.Builder {
+    if (queries.isEmpty()) return this
+    val builderClass = this::class.java
+
+    // Prefer a method accepting a java.util.List
+    val listMethod = builderClass.methods.firstOrNull { method ->
+        method.name == methodName &&
+            method.parameterTypes.size == 1 &&
+            java.util.List::class.java.isAssignableFrom(method.parameterTypes[0])
+    }
+    if (listMethod != null) {
+        listMethod.invoke(this, queries)
+        return this
+    }
+
+    // Fallback to a method accepting an array of Query
+    val arrayMethod = builderClass.methods.firstOrNull { method ->
+        method.name == methodName &&
+            method.parameterTypes.size == 1 &&
+            method.parameterTypes[0].isArray &&
+            method.parameterTypes[0].componentType == Query::class.java
+    }
+    if (arrayMethod != null) {
+        arrayMethod.invoke(this, queries.toTypedArray())
+        return this
+    }
+
+    throw IllegalStateException("BoolQuery.Builder#$methodName accepting List or Array not found")
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/FilterQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/FilterQuery.kt
@@ -10,18 +10,10 @@ fun BoolQuery.Builder.filterQuery(fn: Query.Builder.() -> ObjectBuilder<Query>):
 
 fun BoolQuery.Builder.filterQuery(vararg values: Query?): BoolQuery.Builder {
     val queries = values.asSequence().mapNotNull { it }.toList()
-    return if (queries.isEmpty()) {
-        this
-    } else {
-        this.filter(queries)
-    }
+    return addClause("filter", queries)
 }
 
 fun BoolQuery.Builder.filterQuery(values: List<Query?>?): BoolQuery.Builder {
-    val queries = values?.asSequence()?.mapNotNull { it }?.toList()
-    return if (queries.isNullOrEmpty()) {
-        this
-    } else {
-        this.filter(values.asSequence().mapNotNull { it }.filter { it.term().value()._get() != null }.toList())
-    }
+    val queries = values?.filterNotNull() ?: emptyList()
+    return addClause("filter", queries)
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustNotQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustNotQuery.kt
@@ -7,20 +7,13 @@ import co.elastic.clients.util.ObjectBuilder
 fun BoolQuery.Builder.mustNotQuery(fn: Query.Builder.() -> ObjectBuilder<Query>): BoolQuery.Builder {
     return this.mustNot(fn)
 }
+
 fun BoolQuery.Builder.mustNotQuery(vararg values: Query?): BoolQuery.Builder {
     val queries = values.asSequence().mapNotNull { it }.toList()
-    return if (queries.isEmpty()) {
-        this
-    } else {
-        this.mustNot(queries)
-    }
+    return addClause("mustNot", queries)
 }
 
 fun BoolQuery.Builder.mustNotQuery(values: List<Query?>?): BoolQuery.Builder {
-    val queries = values?.asSequence()?.mapNotNull { it }?.toList()
-    return if (queries.isNullOrEmpty()) {
-        this
-    } else {
-        this.mustNot(values.asSequence().mapNotNull { it }.filter { it.term().value()._get() != null }.toList())
-    }
+    val queries = values?.filterNotNull() ?: emptyList()
+    return addClause("mustNot", queries)
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustQuery.kt
@@ -7,20 +7,13 @@ import co.elastic.clients.util.ObjectBuilder
 fun BoolQuery.Builder.mustQuery(fn: Query.Builder.() -> ObjectBuilder<Query>): BoolQuery.Builder {
     return this.must(fn)
 }
+
 fun BoolQuery.Builder.mustQuery(vararg values: Query?): BoolQuery.Builder {
     val queries = values.asSequence().mapNotNull { it }.toList()
-    return if (queries.isEmpty()) {
-        this
-    } else {
-        this.must(queries)
-    }
+    return addClause("must", queries)
 }
 
 fun BoolQuery.Builder.mustQuery(values: List<Query?>?): BoolQuery.Builder {
-    val queries = values?.asSequence()?.mapNotNull { it }?.toList()
-    return if (queries.isNullOrEmpty()) {
-        this
-    } else {
-        this.must(values.asSequence().mapNotNull { it }.filter { it.term().value()._get() != null }.toList())
-    }
+    val queries = values?.filterNotNull() ?: emptyList()
+    return addClause("must", queries)
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/ShouldQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/ShouldQuery.kt
@@ -10,18 +10,10 @@ fun BoolQuery.Builder.shouldQuery(fn: Query.Builder.() -> ObjectBuilder<Query>):
 
 fun BoolQuery.Builder.shouldQuery(vararg values: Query?): BoolQuery.Builder {
     val queries = values.asSequence().mapNotNull { it }.toList()
-    return if (queries.isEmpty()) {
-        this
-    } else {
-        this.should(queries)
-    }
+    return addClause("should", queries)
 }
 
 fun BoolQuery.Builder.shouldQuery(values: List<Query?>?): BoolQuery.Builder {
-    val queries = values?.asSequence()?.mapNotNull { it }?.toList()
-    return if (queries.isNullOrEmpty()) {
-        this
-    } else {
-        this.should(values.asSequence().mapNotNull { it }.filter { it.term().value()._get() != null }.toList())
-    }
+    val queries = values?.filterNotNull() ?: emptyList()
+    return addClause("should", queries)
 }


### PR DESCRIPTION
## Summary
- Add reflection-based helper to invoke BoolQuery clause methods accepting either a list or vararg, insulating the DSL from client signature changes
- Refactor bool clause helpers to use the new compatibility layer and drop fragile term query filtering
- Configure Kotlin JVM toolchain to 17 for broader client version support

## Testing
- `./gradlew test` *(fails: Could not resolve all dependencies for configuration ':testRuntimeClasspath'. java.io.IOException: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden" )*

------
https://chatgpt.com/codex/tasks/task_e_68a716943d808322afab021cf66153d3