### PR TITLE
refactor: improve client version compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,14 @@ plugins {
     kotlin("jvm") version "1.9.0"
 }
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 group = "com.github.silbaram"
 version = "1.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
+    maven("https://artifacts.elastic.co/maven")
 }
 
 val elasticsearchJavaVersion: String by project
@@ -15,6 +18,12 @@ dependencies {
     implementation("co.elastic.clients:elasticsearch-java:$elasticsearchJavaVersion")
     testImplementation("io.kotest:kotest-runner-junit5:5.7.1")
     testImplementation("io.kotest:kotest-assertions-core:5.7.1")
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
+    }
 }
 
 tasks.withType<Test>().configureEach {

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/FilterQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/FilterQuery.kt
@@ -18,10 +18,10 @@ fun BoolQuery.Builder.filterQuery(vararg values: Query?): BoolQuery.Builder {
 }
 
 fun BoolQuery.Builder.filterQuery(values: List<Query?>?): BoolQuery.Builder {
-    val queries = values?.asSequence()?.mapNotNull { it }?.toList()
-    return if (queries.isNullOrEmpty()) {
+    val queries = values?.filterNotNull() ?: emptyList()
+    return if (queries.isEmpty()) {
         this
     } else {
-        this.filter(values.asSequence().mapNotNull { it }.filter { it.term().value()._get() != null }.toList())
+        this.filter(queries)
     }
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustNotQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustNotQuery.kt
@@ -17,10 +17,10 @@ fun BoolQuery.Builder.mustNotQuery(vararg values: Query?): BoolQuery.Builder {
 }
 
 fun BoolQuery.Builder.mustNotQuery(values: List<Query?>?): BoolQuery.Builder {
-    val queries = values?.asSequence()?.mapNotNull { it }?.toList()
-    return if (queries.isNullOrEmpty()) {
+    val queries = values?.filterNotNull() ?: emptyList()
+    return if (queries.isEmpty()) {
         this
     } else {
-        this.mustNot(values.asSequence().mapNotNull { it }.filter { it.term().value()._get() != null }.toList())
+        this.mustNot(queries)
     }
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustQuery.kt
@@ -17,10 +17,10 @@ fun BoolQuery.Builder.mustQuery(vararg values: Query?): BoolQuery.Builder {
 }
 
 fun BoolQuery.Builder.mustQuery(values: List<Query?>?): BoolQuery.Builder {
-    val queries = values?.asSequence()?.mapNotNull { it }?.toList()
-    return if (queries.isNullOrEmpty()) {
+    val queries = values?.filterNotNull() ?: emptyList()
+    return if (queries.isEmpty()) {
         this
     } else {
-        this.must(values.asSequence().mapNotNull { it }.filter { it.term().value()._get() != null }.toList())
+        this.must(queries)
     }
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/ShouldQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/ShouldQuery.kt
@@ -18,10 +18,10 @@ fun BoolQuery.Builder.shouldQuery(vararg values: Query?): BoolQuery.Builder {
 }
 
 fun BoolQuery.Builder.shouldQuery(values: List<Query?>?): BoolQuery.Builder {
-    val queries = values?.asSequence()?.mapNotNull { it }?.toList()
-    return if (queries.isNullOrEmpty()) {
+    val queries = values?.filterNotNull() ?: emptyList()
+    return if (queries.isEmpty()) {
         this
     } else {
-        this.should(values.asSequence().mapNotNull { it }.filter { it.term().value()._get() != null }.toList())
+        this.should(queries)
     }
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQuery.kt
@@ -42,7 +42,10 @@ fun rangeQuery(
 
     fun invokeIfPresent(name: String, rawValue: Any) {
         val method = builder.javaClass.methods.firstOrNull {
-            it.name == name && it.parameterCount == 1
+            it.name == name &&
+                it.parameterCount == 1 &&
+                (it.parameterTypes[0].isAssignableFrom(JsonData::class.java) ||
+                    it.parameterTypes[0].isAssignableFrom(rawValue.javaClass))
         }
 
         if (method != null) {

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQuery.kt
@@ -42,8 +42,8 @@ fun rangeQuery(
             ?.invoke(builder, value)
     }
 
-    from?.let { invokeIfPresent("from", it) }
-    to?.let { invokeIfPresent("to", it) }
+    from?.let { invokeIfPresent("from", JsonData.of(it)) }
+    to?.let { invokeIfPresent("to", JsonData.of(it)) }
     gt?.let { invokeIfPresent("gt", JsonData.of(it)) }
     lt?.let { invokeIfPresent("lt", JsonData.of(it)) }
     gte?.let { invokeIfPresent("gte", JsonData.of(it)) }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQuery.kt
@@ -29,7 +29,11 @@ fun rangeQuery(
 
     // Set field via reflection to remain compatible with client versions
     builder.javaClass.methods
-        .firstOrNull { it.name == "field" && it.parameterTypes.size == 1 }
+        .firstOrNull {
+            it.name == "field" &&
+                it.parameterTypes.size == 1 &&
+                it.parameterTypes[0].isAssignableFrom(String::class.java)
+        }
         ?.invoke(builder, field)
         ?: builder.javaClass.getDeclaredField("field").apply {
             isAccessible = true
@@ -37,8 +41,13 @@ fun rangeQuery(
         }
 
     fun invokeIfPresent(name: String, value: Any) {
+        val valueType = value::class.java
         builder.javaClass.methods
-            .firstOrNull { it.name == name && it.parameterTypes.size == 1 }
+            .firstOrNull {
+                it.name == name &&
+                    it.parameterTypes.size == 1 &&
+                    it.parameterTypes[0].isAssignableFrom(valueType)
+            }
             ?.invoke(builder, value)
     }
 

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQueryTest.kt
@@ -1,11 +1,30 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.item_level
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery
+import co.elastic.clients.json.JsonData
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.compound_queries.boolQuery
 import io.kotest.assertions.print.print
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+
+private fun RangeQuery.fieldName(): String? {
+    val method = this.javaClass.methods.firstOrNull { it.name == "field" && it.parameterCount == 0 }
+    return if (method != null) {
+        method.invoke(this) as? String
+    } else {
+        val field = this.javaClass.getDeclaredField("field")
+        field.isAccessible = true
+        field.get(this) as? String
+    }
+}
+
+private fun RangeQuery.jsonValue(name: String): JsonData? {
+    return this.javaClass.methods
+        .firstOrNull { it.name == name && it.parameterCount == 0 }
+        ?.invoke(this) as? JsonData
+}
 
 class RangeQueryTest: FunSpec ({
 
@@ -40,16 +59,21 @@ class RangeQueryTest: FunSpec ({
         boolQueryBuild.isBool shouldBe true
         mustQuery.size shouldBe 4
 
-        mustQuery.filter { it.isRange && it.range().field() == "a"}.size shouldBe 2
-        mustQuery.filter { it.isRange && it.range().field() == "b"}.size shouldBe 1
-        mustQuery.filter { it.isRange && it.range().field() == "c"}.size shouldBe 1
+        mustQuery.filter { it.isRange && it.range().fieldName() == "a"}.size shouldBe 2
+        mustQuery.filter { it.isRange && it.range().fieldName() == "b"}.size shouldBe 1
+        mustQuery.filter { it.isRange && it.range().fieldName() == "c"}.size shouldBe 1
 
-
-        mustQuery.filter { it.isRange && it.range().field() == "a" && it.range().from() != null}[0].range().from().print().value shouldBe "\"1234\""
-        mustQuery.filter { it.isRange && it.range().field() == "a" && it.range().to() != null}[0].range().to().print().value shouldBe "\"5678\""
-        mustQuery.filter { it.isRange && it.range().field() == "b"}[0].range().gt().print().value shouldBe "123"
-        mustQuery.filter { it.isRange && it.range().field() == "b"}[0].range().lt().print().value shouldBe "567"
-        mustQuery.filter { it.isRange && it.range().field() == "c"}[0].range().gte().print().value shouldBe "456"
-        mustQuery.filter { it.isRange && it.range().field() == "c"}[0].range().lte().print().value shouldBe "789"
+        mustQuery.filter { it.isRange && it.range().fieldName() == "a" && it.range().jsonValue("from") != null }[0]
+            .range().jsonValue("from")!!.print().value shouldBe "\"1234\""
+        mustQuery.filter { it.isRange && it.range().fieldName() == "a" && it.range().jsonValue("to") != null }[0]
+            .range().jsonValue("to")!!.print().value shouldBe "\"5678\""
+        mustQuery.filter { it.isRange && it.range().fieldName() == "b" }[0]
+            .range().jsonValue("gt")!!.print().value shouldBe "123"
+        mustQuery.filter { it.isRange && it.range().fieldName() == "b" }[0]
+            .range().jsonValue("lt")!!.print().value shouldBe "567"
+        mustQuery.filter { it.isRange && it.range().fieldName() == "c" }[0]
+            .range().jsonValue("gte")!!.print().value shouldBe "456"
+        mustQuery.filter { it.isRange && it.range().fieldName() == "c" }[0]
+            .range().jsonValue("lte")!!.print().value shouldBe "789"
     }
 })

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQueryTest.kt
@@ -5,7 +5,6 @@ import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery
 import co.elastic.clients.json.JsonData
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.compound_queries.boolQuery
-import io.kotest.assertions.print.print
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -75,16 +74,16 @@ class RangeQueryTest: FunSpec ({
         mustQuery.filter { it.isRange && it.range().fieldName() == "c"}.size shouldBe 1
 
         mustQuery.filter { it.isRange && it.range().fieldName() == "a" && it.range().jsonValue("from") != null }[0]
-            .range().jsonValue("from")!!.print().value shouldBe "\"1234\""
+            .range().jsonValue("from")!!.to(String::class.java) shouldBe "1234"
         mustQuery.filter { it.isRange && it.range().fieldName() == "a" && it.range().jsonValue("to") != null }[0]
-            .range().jsonValue("to")!!.print().value shouldBe "\"5678\""
+            .range().jsonValue("to")!!.to(String::class.java) shouldBe "5678"
         mustQuery.filter { it.isRange && it.range().fieldName() == "b" }[0]
-            .range().jsonValue("gt")!!.print().value shouldBe "123"
+            .range().jsonValue("gt")!!.to(Int::class.java) shouldBe 123
         mustQuery.filter { it.isRange && it.range().fieldName() == "b" }[0]
-            .range().jsonValue("lt")!!.print().value shouldBe "567"
+            .range().jsonValue("lt")!!.to(Int::class.java) shouldBe 567
         mustQuery.filter { it.isRange && it.range().fieldName() == "c" }[0]
-            .range().jsonValue("gte")!!.print().value shouldBe "456"
+            .range().jsonValue("gte")!!.to(Int::class.java) shouldBe 456
         mustQuery.filter { it.isRange && it.range().fieldName() == "c" }[0]
-            .range().jsonValue("lte")!!.print().value shouldBe "789"
+            .range().jsonValue("lte")!!.to(Int::class.java) shouldBe 789
     }
 })

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/TermsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/TermsQueryTest.kt
@@ -32,8 +32,8 @@ class TermsQueryTest: FunSpec({
 
         boolQueryBuild.isBool shouldBe true
         mustQuery.size shouldBe 2
-        mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
-        mustQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
+        mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        mustQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("must 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
@@ -66,8 +66,8 @@ class TermsQueryTest: FunSpec({
         mustQuery.size shouldBe 2
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
-        mustQuery.filter { it.isTerms }.find { it.terms().field() == "c" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
-        mustQuery.filter { it.isTerms }.find { it.terms().field() == "d" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333")
+        mustQuery.filter { it.isTerms }.find { it.terms().field() == "c" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        mustQuery.filter { it.isTerms }.find { it.terms().field() == "d" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("3333")
     }
 
     test("must 쿼리에서 termsQuery가 없을때 must쿼리는 생성 안되야함") {
@@ -112,8 +112,8 @@ class TermsQueryTest: FunSpec({
 
         boolQueryBuild.isBool shouldBe true
         filterQuery.size shouldBe 2
-        filterQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
-        filterQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
+        filterQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        filterQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("filter 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
@@ -146,8 +146,8 @@ class TermsQueryTest: FunSpec({
         filterQuery.size shouldBe 2
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
-        filterQuery.filter { it.isTerms }.find { it.terms().field() == "c" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
-        filterQuery.filter { it.isTerms }.find { it.terms().field() == "d" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333")
+        filterQuery.filter { it.isTerms }.find { it.terms().field() == "c" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        filterQuery.filter { it.isTerms }.find { it.terms().field() == "d" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("3333")
     }
 
     test("filter 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
@@ -192,8 +192,8 @@ class TermsQueryTest: FunSpec({
 
         boolQueryBuild.isBool shouldBe true
         mustNotQuery.size shouldBe 2
-        mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
-        mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
+        mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("mustNot 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
@@ -226,8 +226,8 @@ class TermsQueryTest: FunSpec({
         mustNotQuery.size shouldBe 2
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
-        mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "c" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
-        mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "d" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333")
+        mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "c" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "d" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("3333")
     }
 
     test("mustNot 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
@@ -272,8 +272,8 @@ class TermsQueryTest: FunSpec({
 
         boolQueryBuild.isBool shouldBe true
         shouldQuery.size shouldBe 2
-        shouldQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
-        shouldQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
+        shouldQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        shouldQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("should 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
@@ -306,8 +306,8 @@ class TermsQueryTest: FunSpec({
         shouldQuery.size shouldBe 2
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
-        shouldQuery.filter { it.isTerms }.find { it.terms().field() == "c" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
-        shouldQuery.filter { it.isTerms }.find { it.terms().field() == "d" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333")
+        shouldQuery.filter { it.isTerms }.find { it.terms().field() == "c" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        shouldQuery.filter { it.isTerms }.find { it.terms().field() == "d" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("3333")
     }
 
     test("should 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
@@ -349,7 +349,7 @@ class TermsQueryTest: FunSpec({
 
         boolQueryBuild.isBool shouldBe true
         mustQuery.size shouldBe 1
-        mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
+        mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it.stringValue() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().boost() shouldBe 2.5F
     }
 })


### PR DESCRIPTION
## Summary
- avoid internal FieldValue APIs in bool clause helpers
- adjust tests to use public `stringValue` accessors

## Testing
- `./gradlew test` *(fails: Unknown Kotlin JVM target: 21)*


------
https://chatgpt.com/codex/tasks/task_e_68a716943d808322afab021cf66153d3