### PR TITLE
Add constant score query DSL

### DIFF
--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/FilterQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/FilterQuery.kt
@@ -8,7 +8,9 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilde
  * 람다를 사용하여 `filter` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
  * 단일 쿼리 또는 `queries[...]`를 사용한 여러 쿼리를 모두 지원합니다.
  */
-fun BoolQuery.Builder.filterQuery(fn: SubQueryBuilders.() -> Any?): BoolQuery.Builder {
+fun BoolQuery.Builder.filterQuery(
+    fn: SubQueryBuilders.() -> Any?
+): BoolQuery.Builder {
     val builder = SubQueryBuilders()
     val result = builder.fn()
 

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustNotQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustNotQuery.kt
@@ -8,7 +8,9 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilde
  * 람다를 사용하여 `mustNot` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
  * 단일 쿼리 또는 `queries[...]`를 사용한 여러 쿼리를 모두 지원합니다.
  */
-fun BoolQuery.Builder.mustNotQuery(fn: SubQueryBuilders.() -> Any?): BoolQuery.Builder {
+fun BoolQuery.Builder.mustNotQuery(
+    fn: SubQueryBuilders.() -> Any?
+): BoolQuery.Builder {
     val builder = SubQueryBuilders()
     val result = builder.fn()
 

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/MustQuery.kt
@@ -8,7 +8,9 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilde
  * 람다를 사용하여 `must` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
  * 단일 쿼리 또는 `queries[...]`를 사용한 여러 쿼리를 모두 지원합니다.
  */
-fun BoolQuery.Builder.mustQuery(fn: SubQueryBuilders.() -> Any?): BoolQuery.Builder {
+fun BoolQuery.Builder.mustQuery(
+    fn: SubQueryBuilders.() -> Any?
+): BoolQuery.Builder {
     val builder = SubQueryBuilders()
     val result = builder.fn()
 

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/ShouldQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/ShouldQuery.kt
@@ -8,7 +8,9 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilde
  * 람다를 사용하여 `should` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
  * 단일 쿼리 또는 `queries[...]`를 사용한 여러 쿼리를 모두 지원합니다.
  */
-fun BoolQuery.Builder.shouldQuery(fn: SubQueryBuilders.() -> Any?): BoolQuery.Builder {
+fun BoolQuery.Builder.shouldQuery(
+    fn: SubQueryBuilders.() -> Any?
+): BoolQuery.Builder {
     val builder = SubQueryBuilders()
     val result = builder.fn()
 

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/ConstantScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/ConstantScoreQuery.kt
@@ -6,9 +6,9 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilde
 
 fun SubQueryBuilders.constantScoreQuery(
     fn: ConstantScoreQueryDsl.() -> Unit,
-): Query? {
+): SubQueryBuilders {
     val dsl = ConstantScoreQueryDsl().apply(fn)
-    val filterQuery = dsl.buildFilterQuery() ?: return null
+    val filterQuery = dsl.buildFilterQuery() ?: return this
 
     val constantScoreQuery = Query.of { q ->
         q.constantScore { cs ->
@@ -20,6 +20,6 @@ fun SubQueryBuilders.constantScoreQuery(
     }
 
     this.addQuery(constantScoreQuery)
-    return null
+    return this
 }
 

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/ExistsQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/ExistsQuery.kt
@@ -3,7 +3,11 @@ package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_claus
 import co.elastic.clients.elasticsearch._types.query_dsl.ExistsQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 
-fun existsQuery(field: String?, boost: Float? = null, _name: String? = null): Query? {
+fun existsQuery(
+    field: String?,
+    boost: Float? = null,
+    _name: String? = null
+): Query? {
     return if (field.isNullOrEmpty()) {
         null
     } else {

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/RangeQuery.kt
@@ -1,6 +1,5 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.item_level
 
-import co.elastic.clients.elasticsearch._types.query_dsl.ExistsQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery
 import co.elastic.clients.json.JsonData

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/TermQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/TermQuery.kt
@@ -3,7 +3,12 @@ package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_claus
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch._types.query_dsl.TermQuery
 
-fun termQuery(field: String, value: String?, boost: Float? = null, _name: String? = null): Query? {
+fun termQuery(
+    field: String,
+    value: String?,
+    boost: Float? = null,
+    _name: String? = null
+): Query? {
     return if (value.isNullOrEmpty()) {
         null
     } else {

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/TermsQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/TermsQuery.kt
@@ -5,7 +5,12 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.TermsQueryField
 
-fun termsQuery(field: String, values: List<String?>?, boost: Float? = null, _name: String? = null): Query? {
+fun termsQuery(
+    field: String,
+    values: List<String?>?,
+    boost: Float? = null,
+    _name: String? = null
+): Query? {
     val filterValues = values?.mapNotNull { it }
     return if (filterValues?.isNotEmpty() == true) {
         TermsQuery.Builder()

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/BoolQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/BoolQuery.kt
@@ -4,6 +4,8 @@ import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.util.ObjectBuilder
 
-fun Query.Builder.boolQuery(fn: BoolQuery.Builder.() -> ObjectBuilder<BoolQuery>): ObjectBuilder<Query> {
+fun Query.Builder.boolQuery(
+    fn: BoolQuery.Builder.() -> ObjectBuilder<BoolQuery>
+): ObjectBuilder<Query> {
     return this.bool(fn)
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/ConstantScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/ConstantScoreQuery.kt
@@ -8,7 +8,7 @@ class ConstantScoreQueryDsl {
     var boost: Float? = null
     var _name: String? = null
 
-    fun filter(fn: SubQueryBuilders.() -> Any?) {
+    fun filterQuery(fn: SubQueryBuilders.() -> Any?) {
         val subQuery = SubQueryBuilders()
         val result = subQuery.fn()
         if (result is Query) {


### PR DESCRIPTION
## Summary
- add ConstantScoreQueryDsl for building top-level constant_score queries with optional boost and name
- support constant_score within bool clause DSL and prevent duplicate additions
- update bool clause helpers and provide comprehensive tests for constant_score usage

## Testing
- `./gradlew test` *(fails: Could not resolve io.kotest:kotest-runner-junit5:5.7.1, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aba3a0e4508322afc1f0a3340e94b7