### PR TITLE
Add function score query DSL

### DIFF
--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/FunctionScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/FunctionScoreQuery.kt
@@ -1,0 +1,24 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.item_level
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.compound_queries.FunctionScoreQueryDsl
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilders
+
+// bool 쿼리의 각 절에서 function_score를 사용할 수 있도록 하는 확장 함수
+fun SubQueryBuilders.functionScoreQuery(
+    fn: FunctionScoreQueryDsl.() -> Unit,
+): SubQueryBuilders {
+    val dsl = FunctionScoreQueryDsl().apply(fn)
+    if (!dsl.hasValid()) return this
+
+    val functionScoreQuery = Query.of { q ->
+        q.functionScore { fs ->
+            dsl.apply(fs)
+            fs
+        }
+    }
+
+    this.addQuery(functionScoreQuery)
+    return this
+}
+

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/FunctionScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/FunctionScoreQuery.kt
@@ -1,0 +1,145 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.compound_queries
+
+import co.elastic.clients.elasticsearch._types.query_dsl.FieldValueFactorModifier
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionBoostMode
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScore
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilders
+
+// SubQueryBuilders의 쿼리들을 하나의 Query로 합칩니다.
+private fun buildQuery(builder: SubQueryBuilders): Query? {
+    return when (builder.size()) {
+        0 -> null
+        1 -> {
+            var result: Query? = null
+            builder.forEach { result = it }
+            result
+        }
+        else -> Query.of { q ->
+            q.bool { b ->
+                builder.forEach { b.must(it) }
+                b
+            }
+        }
+    }
+}
+
+// function_score 의 functions 절을 구성하기 위한 DSL
+class FunctionScoreFunctionsDsl {
+    private val functions = mutableListOf<FunctionScore>()
+
+    /**
+     * weight 함수를 추가합니다.
+     * @param weight 적용할 가중치 값
+     * @param filter weight가 적용될 대상 문서를 선택하는 필터 쿼리
+     */
+    fun weight(weight: Double, filter: (SubQueryBuilders.() -> Any?)? = null) {
+        val builder = FunctionScore.Builder().weight(weight)
+        filter?.let {
+            val sub = SubQueryBuilders()
+            val result = sub.it()
+            if (result is Query) sub.addQuery(result)
+            buildQuery(sub)?.let { builder.filter(it) }
+        }
+        functions.add(builder.build())
+    }
+
+    /**
+     * field_value_factor 함수를 추가합니다.
+     * @param field 점수 계산에 사용할 필드
+     * @param factor 곱해질 계수
+     * @param missing 필드가 존재하지 않을 때 사용될 기본값
+     * @param modifier 값에 적용할 변형 함수
+     * @param filter 함수 적용 대상 문서를 선택하는 필터 쿼리
+     * @param weight 함수에 적용할 가중치
+     */
+    fun fieldValueFactor(
+        field: String,
+        factor: Double? = null,
+        missing: Double? = null,
+        modifier: FieldValueFactorModifier? = null,
+        filter: (SubQueryBuilders.() -> Any?)? = null,
+        weight: Double? = null,
+    ) {
+        val builder = FunctionScore.Builder()
+        builder.fieldValueFactor { fvf ->
+            fvf.field(field)
+            factor?.let { fvf.factor(it) }
+            missing?.let { fvf.missing(it) }
+            modifier?.let { fvf.modifier(it) }
+            fvf
+        }
+        weight?.let { builder.weight(it) }
+        filter?.let {
+            val sub = SubQueryBuilders()
+            val result = sub.it()
+            if (result is Query) sub.addQuery(result)
+            buildQuery(sub)?.let { builder.filter(it) }
+        }
+        functions.add(builder.build())
+    }
+
+    internal fun build(): List<FunctionScore> = functions
+}
+
+// function_score 쿼리 DSL
+class FunctionScoreQueryDsl {
+    private var baseQuery: Query? = null
+    private val scoringFunctions = mutableListOf<FunctionScore>()
+
+    var boost: Float? = null
+    var boostMode: FunctionBoostMode? = null
+    var scoreMode: FunctionScoreMode? = null
+    var maxBoost: Double? = null
+    var minScore: Double? = null
+    var _name: String? = null
+
+    /**
+     * function_score의 query 절을 설정합니다.
+     */
+    fun query(fn: SubQueryBuilders.() -> Any?) {
+        val sub = SubQueryBuilders()
+        val result = sub.fn()
+        if (result is Query) {
+            sub.addQuery(result)
+        }
+        baseQuery = buildQuery(sub)
+    }
+
+    /**
+     * function_score의 functions 절을 설정합니다.
+     */
+    fun functions(fn: FunctionScoreFunctionsDsl.() -> Unit) {
+        val dsl = FunctionScoreFunctionsDsl().apply(fn)
+        scoringFunctions.addAll(dsl.build())
+    }
+
+    internal fun hasValid(): Boolean = scoringFunctions.isNotEmpty()
+
+    internal fun apply(builder: FunctionScoreQuery.Builder): FunctionScoreQuery.Builder {
+        baseQuery?.let { builder.query(it) }
+        if (scoringFunctions.isNotEmpty()) {
+            builder.functions(scoringFunctions)
+        }
+        boost?.let { builder.boost(it) }
+        boostMode?.let { builder.boostMode(it) }
+        scoreMode?.let { builder.scoreMode(it) }
+        maxBoost?.let { builder.maxBoost(it) }
+        minScore?.let { builder.minScore(it) }
+        _name?.let { builder.queryName(it) }
+        return builder
+    }
+}
+
+// 최상위 function_score 쿼리 확장 함수
+fun Query.Builder.functionScoreQuery(fn: FunctionScoreQueryDsl.() -> Unit) {
+    val dsl = FunctionScoreQueryDsl().apply(fn)
+    if (!dsl.hasValid()) return
+    this.functionScore { fs ->
+        dsl.apply(fs)
+        fs
+    }
+}
+

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/FunctionScoreQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/FunctionScoreQueryTest.kt
@@ -1,0 +1,108 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.compound_queries
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.filterQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.mustNotQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.shouldQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.item_level.functionScoreQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.item_level.termQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.query
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionBoostMode
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class FunctionScoreQueryTest : FunSpec({
+
+    test("최상위 function_score 쿼리가 올바르게 생성되어야 한다") {
+        val q = query {
+            functionScoreQuery {
+                query {
+                    termQuery(field = "title", value = "apple")
+                }
+                functions {
+                    weight(2.0)
+                }
+                boostMode = FunctionBoostMode.Multiply
+                scoreMode = FunctionScoreMode.Sum
+                boost = 1.2f
+            }
+        }
+
+        q.isFunctionScore shouldBe true
+        val fs = q.functionScore()
+        fs.query()?.isTerm shouldBe true
+        fs.functions().size shouldBe 1
+        fs.functions().first().weight() shouldBe 2.0
+        fs.boostMode() shouldBe FunctionBoostMode.Multiply
+        fs.scoreMode() shouldBe FunctionScoreMode.Sum
+        fs.boost() shouldBe 1.2f
+    }
+
+    test("function_score는 bool 쿼리의 각 절에서 사용될 수 있다") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    functionScoreQuery {
+                        query { termQuery("title", "apple") }
+                        functions { weight(2.0) }
+                    }
+                }
+                filterQuery {
+                    functionScoreQuery {
+                        query { termQuery("tag", "tech") }
+                        functions { weight(3.0) }
+                    }
+                }
+                mustNotQuery {
+                    functionScoreQuery {
+                        query { termQuery("status", "inactive") }
+                        functions { weight(1.0) }
+                    }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        q.bool().must().size shouldBe 1
+        q.bool().filter().size shouldBe 1
+        q.bool().mustNot().size shouldBe 1
+
+        q.bool().must().first().functionScore().functions().first().weight() shouldBe 2.0
+        q.bool().filter().first().functionScore().functions().first().weight() shouldBe 3.0
+        q.bool().mustNot().first().functionScore().functions().first().weight() shouldBe 1.0
+    }
+
+    test("함수가 비어있을 때 최상위 function_score는 건너뛰어야 한다") {
+        shouldThrow<Exception> {
+            query {
+                functionScoreQuery {
+                    query { termQuery("title", "apple") }
+                }
+            }
+        }
+    }
+
+    test("field_value_factor 함수가 적용되어야 한다") {
+        val q = query {
+            functionScoreQuery {
+                query { termQuery("title", "apple") }
+                functions {
+                    fieldValueFactor(
+                        field = "likes",
+                        factor = 1.2,
+                        missing = 1.0,
+                    )
+                }
+            }
+        }
+
+        q.isFunctionScore shouldBe true
+        val function = q.functionScore().functions().first()
+        function.fieldValueFactor().field() shouldBe "likes"
+        function.fieldValueFactor().factor() shouldBe 1.2
+        function.fieldValueFactor().missing() shouldBe 1.0
+    }
+})
+


### PR DESCRIPTION
## Summary
- support function_score query with weight and field value factor functions
- allow function_score inside bool clauses
- test function score query behavior

## Testing
- `./gradlew test` *(fails: Could not resolve io.kotest:kotest-runner-junit5:5.7.1)*

------
https://chatgpt.com/codex/tasks/task_e_68adb162e97c83228487aa0979b3bd25