### PR TITLE
Add function_score query DSL

### DIFF
--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/FunctionScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/bool_clauses/item_level/FunctionScoreQuery.kt
@@ -1,0 +1,29 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.item_level
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.compound_queries.FunctionScoreQueryDsl
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilders
+
+fun SubQueryBuilders.functionScoreQuery(
+    fn: FunctionScoreQueryDsl.() -> Unit,
+): SubQueryBuilders {
+    val dsl = FunctionScoreQueryDsl().apply(fn)
+    val innerQuery = dsl.buildQuery()
+    val fsQuery = Query.of { q ->
+        q.functionScore { fs ->
+            innerQuery?.let { fs.query(it) }
+            val funcs = dsl.buildFunctions()
+            if (funcs.isNotEmpty()) fs.functions(funcs)
+            dsl.maxBoost?.let { fs.maxBoost(it) }
+            dsl.minScore?.let { fs.minScore(it) }
+            dsl.scoreMode?.let { fs.scoreMode(it) }
+            dsl.boostMode?.let { fs.boostMode(it) }
+            dsl.boost?.let { fs.boost(it) }
+            dsl._name?.let { fs.queryName(it) }
+            fs
+        }
+    }
+    this.addQuery(fsQuery)
+    return this
+}
+

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/FunctionScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/FunctionScoreQuery.kt
@@ -1,0 +1,127 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.compound_queries
+
+import co.elastic.clients.elasticsearch._types.query_dsl.FieldValueFactorScoreFunction
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionBoostMode
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScore
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.RandomScoreFunction
+import co.elastic.clients.elasticsearch._types.query_dsl.ScriptScoreFunction
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.SubQueryBuilders
+
+class FunctionScoreQueryDsl {
+    private var query: Query? = null
+    private val functions = mutableListOf<FunctionScore>()
+
+    var boostMode: FunctionBoostMode? = null
+    var scoreMode: FunctionScoreMode? = null
+    var maxBoost: Double? = null
+    var minScore: Double? = null
+    var boost: Float? = null
+    var _name: String? = null
+
+    fun query(fn: SubQueryBuilders.() -> Any?) {
+        val subQuery = SubQueryBuilders()
+        val result = subQuery.fn()
+        if (result is Query) {
+            subQuery.addQuery(result)
+        }
+        query = when (subQuery.size()) {
+            0 -> null
+            1 -> {
+                var resultQuery: Query? = null
+                subQuery.forEach { resultQuery = it }
+                resultQuery
+            }
+            else -> Query.of { q ->
+                q.bool { b ->
+                    subQuery.forEach { b.must(it) }
+                    b
+                }
+            }
+        }
+    }
+
+    fun function(fn: ScoreFunctionDsl.() -> Unit) {
+        val dsl = ScoreFunctionDsl().apply(fn)
+        dsl.build()?.let { functions.add(it) }
+    }
+
+    internal fun buildQuery(): Query? = query
+
+    internal fun buildFunctions(): List<FunctionScore> = functions
+}
+
+class ScoreFunctionDsl {
+    private val filterQueries = SubQueryBuilders()
+    var weight: Double? = null
+    private var randomScore: RandomScoreFunction? = null
+    private var fieldValueFactor: FieldValueFactorScoreFunction? = null
+    private var scriptScore: ScriptScoreFunction? = null
+
+    fun filter(fn: SubQueryBuilders.() -> Any?) {
+        val subQuery = SubQueryBuilders()
+        val result = subQuery.fn()
+        if (result is Query) {
+            subQuery.addQuery(result)
+        }
+        filterQueries.addAll(subQuery)
+    }
+
+    fun randomScore(fn: RandomScoreFunction.Builder.() -> Unit) {
+        randomScore = RandomScoreFunction.Builder().apply(fn).build()
+    }
+
+    fun fieldValueFactor(fn: FieldValueFactorScoreFunction.Builder.() -> Unit) {
+        fieldValueFactor = FieldValueFactorScoreFunction.Builder().apply(fn).build()
+    }
+
+    fun scriptScore(fn: ScriptScoreFunction.Builder.() -> Unit) {
+        scriptScore = ScriptScoreFunction.Builder().apply(fn).build()
+    }
+
+    internal fun build(): FunctionScore? {
+        if (weight == null && randomScore == null && fieldValueFactor == null && scriptScore == null) {
+            return null
+        }
+        return FunctionScore.Builder().apply {
+            val filterQuery = when (filterQueries.size()) {
+                0 -> null
+                1 -> {
+                    var result: Query? = null
+                    filterQueries.forEach { result = it }
+                    result
+                }
+                else -> Query.of { q ->
+                    q.bool { b ->
+                        filterQueries.forEach { b.must(it) }
+                        b
+                    }
+                }
+            }
+            filterQuery?.let { filter(it) }
+            weight?.let { weight(it) }
+            randomScore?.let { randomScore(it) }
+            fieldValueFactor?.let { fieldValueFactor(it) }
+            scriptScore?.let { scriptScore(it) }
+        }.build()
+    }
+}
+
+fun Query.Builder.functionScoreQuery(fn: FunctionScoreQueryDsl.() -> Unit) {
+    val dsl = FunctionScoreQueryDsl().apply(fn)
+    val innerQuery = dsl.buildQuery()
+    this.functionScore { fs ->
+        innerQuery?.let { fs.query(it) }
+        val funcs = dsl.buildFunctions()
+        if (funcs.isNotEmpty()) fs.functions(funcs)
+        dsl.maxBoost?.let { fs.maxBoost(it) }
+        dsl.minScore?.let { fs.minScore(it) }
+        dsl.scoreMode?.let { fs.scoreMode(it) }
+        dsl.boostMode?.let { fs.boostMode(it) }
+        dsl.boost?.let { fs.boost(it) }
+        dsl._name?.let { fs.queryName(it) }
+        fs
+    }
+}
+

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/FunctionScoreQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/expansion/compound_queries/FunctionScoreQueryTest.kt
@@ -1,0 +1,65 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.compound_queries
+
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionBoostMode
+import co.elastic.clients.elasticsearch._types.query_dsl.FunctionScoreMode
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.expansion.bool_clauses.item_level.termQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.helper.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class FunctionScoreQueryTest : FunSpec({
+
+    test("function_score 쿼리가 올바르게 생성되어야 한다") {
+        val q = query {
+            functionScoreQuery {
+                query {
+                    termQuery(field = "field1", value = "value1")
+                }
+                function {
+                    weight = 2.0
+                    filter {
+                        termQuery(field = "field2", value = "value2")
+                    }
+                }
+                boostMode = FunctionBoostMode.Multiply
+                scoreMode = FunctionScoreMode.Sum
+                maxBoost = 5.0
+                minScore = 0.1
+                boost = 1.5f
+                _name = "fs"
+            }
+        }
+
+        q.isFunctionScore shouldBe true
+        val fs = q.functionScore()
+        fs.query().term().field() shouldBe "field1"
+        fs.functions().size shouldBe 1
+        val func = fs.functions().first()
+        func.weight() shouldBe 2.0
+        func.filter().term().field() shouldBe "field2"
+        fs.boostMode() shouldBe FunctionBoostMode.Multiply
+        fs.scoreMode() shouldBe FunctionScoreMode.Sum
+        fs.maxBoost() shouldBe 5.0
+        fs.minScore() shouldBe 0.1
+        fs.boost() shouldBe 1.5f
+        fs.queryName() shouldBe "fs"
+    }
+
+    test("function_score는 bool 절 내부에서 사용될 수 있다") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    functionScoreQuery {
+                        query { termQuery("title", "elastic") }
+                        function { weight = 2.0 }
+                    }
+                }
+            }
+        }
+
+        q.bool().must().size shouldBe 1
+        val fs = q.bool().must().first().functionScore()
+        fs.functions().first().weight() shouldBe 2.0
+    }
+})
+


### PR DESCRIPTION
## Summary
- support building Elasticsearch function_score query in Kotlin DSL
- allow function score queries inside bool clauses
- add tests for function_score DSL

## Testing
- `./gradlew test` *(fails: Could not resolve io.kotest artifacts from Maven central; status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68adb162e97c83228487aa0979b3bd25