### PR TITLE
Refactor query tests to use new query DSL

### DIFF
--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/BoolQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/BoolQueryTest.kt
@@ -1,168 +1,168 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound
 
-import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.filterQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustNotQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.shouldQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class BoolQueryTest: FunSpec({
 
     test("bool에 filter query가 추가 되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            filterQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
+        val q = query {
+            boolQuery {
+                filterQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
             }
         }
 
-        val boolQueryBuild = boolQuery.build()
-
-        boolQueryBuild.isBool shouldBe true
-        boolQueryBuild.bool().filter().size shouldBe 1
-        boolQueryBuild.bool().must().size shouldBe 0
-        boolQueryBuild.bool().mustNot().size shouldBe 0
-        boolQueryBuild.bool().should().size shouldBe 0
+        q.isBool shouldBe true
+        q.bool().filter().size shouldBe 1
+        q.bool().must().size shouldBe 0
+        q.bool().mustNot().size shouldBe 0
+        q.bool().should().size shouldBe 0
     }
 
     test("bool에 must query가 추가 되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            mustQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
             }
         }
 
-        val boolQueryBuild = boolQuery.build()
-
-        boolQueryBuild.isBool shouldBe true
-        boolQueryBuild.bool().filter().size shouldBe 0
-        boolQueryBuild.bool().must().size shouldBe 1
-        boolQueryBuild.bool().mustNot().size shouldBe 0
-        boolQueryBuild.bool().should().size shouldBe 0
+        q.isBool shouldBe true
+        q.bool().filter().size shouldBe 0
+        q.bool().must().size shouldBe 1
+        q.bool().mustNot().size shouldBe 0
+        q.bool().should().size shouldBe 0
     }
 
     test("bool에 mustNot query가 추가 되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            mustNotQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
+        val q = query {
+            boolQuery {
+                mustNotQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
             }
         }
 
-        val boolQueryBuild = boolQuery.build()
-
-        boolQueryBuild.isBool shouldBe true
-        boolQueryBuild.bool().filter().size shouldBe 0
-        boolQueryBuild.bool().must().size shouldBe 0
-        boolQueryBuild.bool().mustNot().size shouldBe 1
-        boolQueryBuild.bool().should().size shouldBe 0
+        q.isBool shouldBe true
+        q.bool().filter().size shouldBe 0
+        q.bool().must().size shouldBe 0
+        q.bool().mustNot().size shouldBe 1
+        q.bool().should().size shouldBe 0
     }
 
     test("bool에 should query가 추가 되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            shouldQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
+        val q = query {
+            boolQuery {
+                shouldQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
             }
         }
 
-        val boolQueryBuild = boolQuery.build()
-
-        boolQueryBuild.isBool shouldBe true
-        boolQueryBuild.bool().filter().size shouldBe 0
-        boolQueryBuild.bool().must().size shouldBe 0
-        boolQueryBuild.bool().mustNot().size shouldBe 0
-        boolQueryBuild.bool().should().size shouldBe 1
+        q.isBool shouldBe true
+        q.bool().filter().size shouldBe 0
+        q.bool().must().size shouldBe 0
+        q.bool().mustNot().size shouldBe 0
+        q.bool().should().size shouldBe 1
     }
 
     test("bool에 filter, must, mustNot, should query가 추가 되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            filterQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
-            }
-            mustQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
-            }
-            mustNotQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
-            }
-            shouldQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
+        val q = query {
+            boolQuery {
+                filterQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
+                mustQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
+                mustNotQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
+                shouldQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
             }
         }
 
-        val boolQueryBuild = boolQuery.build()
-
-        boolQueryBuild.isBool shouldBe true
-        boolQueryBuild.bool().filter().size shouldBe 1
-        boolQueryBuild.bool().must().size shouldBe 1
-        boolQueryBuild.bool().mustNot().size shouldBe 1
-        boolQueryBuild.bool().should().size shouldBe 1
+        q.isBool shouldBe true
+        q.bool().filter().size shouldBe 1
+        q.bool().must().size shouldBe 1
+        q.bool().mustNot().size shouldBe 1
+        q.bool().should().size shouldBe 1
     }
 
     test("bool에 minimumShouldMatch, boost가 추가 되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            filterQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
+        val q = query {
+            boolQuery {
+                filterQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
+                mustQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
+                mustNotQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
+                shouldQuery {
+                    termQuery(
+                        field = "field1",
+                        value = "value1"
+                    )
+                }
+                minimumShouldMatch("2")
+                boost(2.0F)
             }
-            mustQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
-            }
-            mustNotQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
-            }
-            shouldQuery {
-                termQuery(
-                    field = "field1",
-                    value = "value1"
-                )
-            }
-            minimumShouldMatch("2")
-            boost(2.0F)
         }
 
-        val boolQueryBuild = boolQuery.build()
-
-        boolQueryBuild.isBool shouldBe true
-        boolQueryBuild.bool().filter().size shouldBe 1
-        boolQueryBuild.bool().must().size shouldBe 1
-        boolQueryBuild.bool().mustNot().size shouldBe 1
-        boolQueryBuild.bool().should().size shouldBe 1
-        boolQueryBuild.bool().minimumShouldMatch() shouldBe "2"
-        boolQueryBuild.bool().boost() shouldBe 2.0F
+        q.isBool shouldBe true
+        q.bool().filter().size shouldBe 1
+        q.bool().must().size shouldBe 1
+        q.bool().mustNot().size shouldBe 1
+        q.bool().should().size shouldBe 1
+        q.bool().minimumShouldMatch() shouldBe "2"
+        q.bool().boost() shouldBe 2.0F
     }
 })

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/SubQueryBuildersTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/SubQueryBuildersTest.kt
@@ -1,10 +1,10 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound
 
-import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.shouldQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -12,8 +12,8 @@ class NestedBoolQueryTest : FunSpec({
 
     test("mustQuery 내부에 중첩된 bool 쿼리가 올바르게 생성되어야 한다") {
         // given
-        val query = Query.Builder()
-            .boolQuery { // 최상위 bool
+        val query = query {
+            boolQuery { // 최상위 bool
                 mustQuery {
                     // 중첩 bool 쿼리 생성
                     boolQuery {
@@ -26,7 +26,7 @@ class NestedBoolQueryTest : FunSpec({
                     }
                 }
             }
-            .build()
+        }
 
         // when
         val topLevelBool = query.bool()
@@ -47,8 +47,8 @@ class NestedBoolQueryTest : FunSpec({
 
     test("shouldQuery 내부에 중첩된 bool 쿼리가 올바르게 생성되어야 한다") {
         // given
-        val query = Query.Builder()
-            .boolQuery { // 최상위 bool
+        val query = query {
+            boolQuery { // 최상위 bool
                 shouldQuery {
                     // 중첩 bool 쿼리 생성
                     boolQuery {
@@ -58,7 +58,7 @@ class NestedBoolQueryTest : FunSpec({
                     }
                 }
             }
-            .build()
+        }
 
         // when
         val topLevelBool = query.bool()
@@ -80,8 +80,8 @@ class NestedBoolQueryTest : FunSpec({
 
     test("하나의 절에 여러 개의 중첩 bool 쿼리를 추가할 수 있어야 한다") {
         // given
-        val query = Query.Builder()
-            .boolQuery {
+        val query = query {
+            boolQuery {
                 mustQuery {
                     queries[
                         // 첫 번째 중첩 bool
@@ -95,7 +95,7 @@ class NestedBoolQueryTest : FunSpec({
                     ]
                 }
             }
-            .build()
+        }
 
         // when
         val mustClauses = query.bool().must()

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/ExistsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/ExistsQueryTest.kt
@@ -1,36 +1,35 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel
 
-import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.existsQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class ExistsQueryTest: FunSpec ({
 
     test("must 쿼리에서 exists 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     existsQuery(
                         field = "a"
                     )
                 }
             }
-
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-        boolQueryBuild.isBool shouldBe true
+        }
+        val mustQuery = q.bool().must()
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.first().isExists shouldBe true
         mustQuery.first().exists().field() shouldBe "a"
     }
 
     test("must 쿼리에서 exists 쿼리 생성시 field가 null이면 existsQuery가 빠져서 생성되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     // 하위 쿼리에 여러개를 추가 해야 할경우 queries[...] 구문 사용
                     queries[
@@ -44,19 +43,18 @@ class ExistsQueryTest: FunSpec ({
                     ]
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1 // termQuery만 추가되어 크기는 1
         mustQuery.first().isTerm shouldBe true
         mustQuery.first().term().field() shouldBe "a"
     }
 
     test("exists 쿼리에 boost 설정시 적용이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     existsQuery(
                         field = "a",
@@ -64,19 +62,18 @@ class ExistsQueryTest: FunSpec ({
                     )
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isExists }.find { it.exists().field() == "a" }?.exists()?.field() shouldBe "a"
         mustQuery.filter { it.isExists }.find { it.exists().field() == "a" }?.exists()?.boost() shouldBe 2.0F
     }
 
     test("exists 쿼리에 _name이 설정되면 terms.queryName에 반영되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     existsQuery(
                         field = "a",
@@ -84,11 +81,10 @@ class ExistsQueryTest: FunSpec ({
                     )
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isExists }.find { it.exists().field() == "a" }?.exists()?.field() shouldBe "a"
         mustQuery.filter { it.isExists }.find { it.exists().field() == "a" }?.exists()?.queryName() shouldBe "named"

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/RangeQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/RangeQueryTest.kt
@@ -1,9 +1,9 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel
 
-import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.rangeQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.assertions.print.print
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -12,8 +12,8 @@ import io.kotest.matchers.shouldBe
 class RangeQueryTest: FunSpec ({
 
     test("must 쿼리에서 range 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     queries[
                         rangeQuery(
@@ -37,11 +37,10 @@ class RangeQueryTest: FunSpec ({
                     ]
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 4
 
         mustQuery.filter { it.isRange && it.range().field() == "a"}.size shouldBe 2
@@ -58,8 +57,8 @@ class RangeQueryTest: FunSpec ({
     }
 
     test("must 쿼리에서 rangeQuery에 boost 설정시 적용이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     rangeQuery(
                         field = "d",
@@ -69,31 +68,30 @@ class RangeQueryTest: FunSpec ({
                     )
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isRange }.find { it.range().field() == "d" }?.range()?.boost() shouldBe 3.0F
     }
 
     test("range 쿼리에 _name이 설정되면 range.queryName에 반영되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            mustQuery {
-                rangeQuery(
-                    field = "d",
-                    gte = 10,
-                    lte = 20,
-                    _name = "named"
-                )
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    rangeQuery(
+                        field = "d",
+                        gte = 10,
+                        lte = 20,
+                        _name = "named"
+                    )
+                }
             }
         }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isRange }.find { it.range().field() == "d" }!!.range().queryName() shouldBe "named"
     }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermQueryTest.kt
@@ -1,20 +1,20 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel
 
-import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.filterQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustNotQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.shouldQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
 class TermQueryTest: FunSpec({
 
     test("must 쿼리에서 term 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     queries[
                         termQuery(
@@ -28,19 +28,18 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 2
         mustQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         mustQuery.filter { it.isTerm }.find { it.term().field() == "b" }?.term()?.value()?.stringValue() shouldBe "2222"
     }
 
     test("must 쿼리에서 termQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     queries[
                         termQuery(
@@ -58,11 +57,10 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isTerm }.find { it.term().field() == "a" } shouldBe null
         mustQuery.filter { it.isTerm }.find { it.term().field() == "b" } shouldBe null
@@ -70,8 +68,8 @@ class TermQueryTest: FunSpec({
     }
 
     test("must 쿼리에서 termQuery 송성값이 없어 생성이 안되어 하위 쿼리가 없을때 must쿼리는 생성 안되야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     queries[
                         termQuery(
@@ -85,18 +83,16 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        println("boolQueryBuild = $boolQueryBuild")
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 0
     }
 
     test("filter 쿼리에서 term 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 filterQuery {
                     queries[
                         termQuery(
@@ -110,19 +106,18 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val filterQuery = q.bool().filter()
 
-        val boolQueryBuild = boolQuery.build()
-        val filterQuery = boolQueryBuild.bool().filter()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         filterQuery.size shouldBe 2
         filterQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         filterQuery.filter { it.isTerm }.find { it.term().field() == "b" }?.term()?.value()?.stringValue() shouldBe "2222"
     }
 
     test("filter 쿼리에서 termQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 filterQuery {
                     queries[
                         termQuery(
@@ -140,11 +135,10 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val filterQuery = q.bool().filter()
 
-        val boolQueryBuild = boolQuery.build()
-        val filterQuery = boolQueryBuild.bool().filter()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         filterQuery.size shouldBe 1
         filterQuery.filter { it.isTerm }.find { it.term().field() == "a" } shouldBe null
         filterQuery.filter { it.isTerm }.find { it.term().field() == "b" } shouldBe null
@@ -152,8 +146,8 @@ class TermQueryTest: FunSpec({
     }
 
     test("filter 쿼리에서 termQuery가 없을때 must쿼리는 생성 안되야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 filterQuery {
                     queries[
                         termQuery(
@@ -167,17 +161,16 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val filterQuery = q.bool().filter()
 
-        val boolQueryBuild = boolQuery.build()
-        val filterQuery = boolQueryBuild.bool().filter()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         filterQuery.size shouldBe 0
     }
 
     test("mustNot 쿼리에서 term 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustNotQuery {
                     queries[
                         termQuery(
@@ -191,19 +184,18 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustNotQuery = q.bool().mustNot()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustNotQuery = boolQueryBuild.bool().mustNot()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustNotQuery.size shouldBe 2
         mustNotQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         mustNotQuery.filter { it.isTerm }.find { it.term().field() == "b" }?.term()?.value()?.stringValue() shouldBe "2222"
     }
 
     test("mustNot 쿼리에서 termQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustNotQuery {
                     queries[
                         termQuery(
@@ -221,11 +213,10 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustNotQuery = q.bool().mustNot()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustNotQuery = boolQueryBuild.bool().mustNot()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustNotQuery.size shouldBe 1
         mustNotQuery.filter { it.isTerm }.find { it.term().field() == "a" } shouldBe null
         mustNotQuery.filter { it.isTerm }.find { it.term().field() == "b" } shouldBe null
@@ -233,8 +224,8 @@ class TermQueryTest: FunSpec({
     }
 
     test("mustNot 쿼리에서 termQuery가 없을때 must쿼리는 생성 안되야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustNotQuery {
                     queries[
                         termQuery(
@@ -248,17 +239,16 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustNotQuery = q.bool().mustNot()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustNotQuery = boolQueryBuild.bool().mustNot()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustNotQuery.size shouldBe 0
     }
 
     test("should 쿼리에서 term 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 shouldQuery {
                     queries[
                         termQuery(
@@ -272,20 +262,18 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val shouldQuery = q.bool().should()
 
-        val boolQueryBuild = boolQuery.build()
-        println("boolQueryBuild = $boolQueryBuild")
-        val shouldQuery = boolQueryBuild.bool().should()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         shouldQuery.size shouldBe 2
         shouldQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         shouldQuery.filter { it.isTerm }.find { it.term().field() == "b" }?.term()?.value()?.stringValue() shouldBe "2222"
     }
 
     test("should 쿼리에서 termQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 shouldQuery {
                     queries[
                         termQuery(
@@ -303,11 +291,10 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val shouldQuery = q.bool().should()
 
-        val boolQueryBuild = boolQuery.build()
-        val shouldQuery = boolQueryBuild.bool().should()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         shouldQuery.size shouldBe 1
         shouldQuery.filter { it.isTerm }.find { it.term().field() == "a" } shouldBe null
         shouldQuery.filter { it.isTerm }.find { it.term().field() == "b" } shouldBe null
@@ -315,8 +302,8 @@ class TermQueryTest: FunSpec({
     }
 
     test("should 쿼리에서 termQuery가 없을때 must쿼리는 생성 안되야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 shouldQuery {
                     queries[
                         termQuery(
@@ -330,49 +317,48 @@ class TermQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val shouldQuery = q.bool().should()
 
-        val boolQueryBuild = boolQuery.build()
-        val shouldQuery = boolQueryBuild.bool().should()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         shouldQuery.size shouldBe 0
     }
 
     test("term 쿼리에 boost 설정시 적용이 되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            mustQuery {
-                termQuery(
-                    field = "a",
-                    value = "1111",
-                    boost = 2.0F
-                )
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    termQuery(
+                        field = "a",
+                        value = "1111",
+                        boost = 2.0F
+                    )
+                }
             }
         }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         mustQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.boost() shouldBe 2.0F
     }
 
     test("term 쿼리에 _name이 설정되면 term.queryName에 반영되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            mustQuery {
-                termQuery(
-                    field = "a",
-                    value = "1111",
-                    _name = "named"
-                )
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    termQuery(
+                        field = "a",
+                        value = "1111",
+                        _name = "named"
+                    )
+                }
             }
         }
+        val mustList = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustList = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustList.size shouldBe 1
 
         val term = mustList.first().term()

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermsQueryTest.kt
@@ -1,12 +1,12 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel
 
-import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.filterQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustNotQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.shouldQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termsQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -14,8 +14,8 @@ import io.kotest.matchers.shouldBe
 class TermsQueryTest: FunSpec({
 
     test("must 쿼리에서 terms 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     queries[
                         termsQuery(
@@ -29,19 +29,18 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 2
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("must 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     queries[
                         termsQuery(
@@ -63,11 +62,10 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 2
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
@@ -76,8 +74,8 @@ class TermsQueryTest: FunSpec({
     }
 
     test("must 쿼리에서 termsQuery가 없을때 must쿼리는 생성 안되야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     queries[
                         termsQuery(
@@ -91,17 +89,17 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
+        val mustQuery = q.bool().must()
 
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 0
     }
 
     test("filter 쿼리에서 terms 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 filterQuery{
                     queries[
                         termsQuery(
@@ -115,19 +113,18 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val filterQuery = q.bool().filter()
 
-        val boolQueryBuild = boolQuery.build()
-        val filterQuery = boolQueryBuild.bool().filter()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         filterQuery.size shouldBe 2
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("filter 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 filterQuery {
                     queries[
                         termsQuery(
@@ -149,11 +146,10 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val filterQuery = q.bool().filter()
 
-        val boolQueryBuild = boolQuery.build()
-        val filterQuery = boolQueryBuild.bool().filter()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         filterQuery.size shouldBe 2
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
@@ -162,8 +158,8 @@ class TermsQueryTest: FunSpec({
     }
 
     test("filter 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 filterQuery {
                     queries[
                         termsQuery(
@@ -177,17 +173,17 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
 
-        val boolQueryBuild = boolQuery.build()
-        val filterQuery = boolQueryBuild.bool().filter()
+        val filterQuery = q.bool().filter()
 
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         filterQuery.size shouldBe 0
     }
 
     test("mustNot 쿼리에서 terms 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustNotQuery {
                     queries[
                         termsQuery(
@@ -201,19 +197,18 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustNotQuery = q.bool().mustNot()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustNotQuery = boolQueryBuild.bool().mustNot()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustNotQuery.size shouldBe 2
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("mustNot 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustNotQuery {
                     queries[
                         termsQuery(
@@ -235,11 +230,10 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustNotQuery = q.bool().mustNot()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustNotQuery = boolQueryBuild.bool().mustNot()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustNotQuery.size shouldBe 2
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
@@ -248,8 +242,8 @@ class TermsQueryTest: FunSpec({
     }
 
     test("mustNot 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 filterQuery {
                     queries[
                         termsQuery(
@@ -263,17 +257,16 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val mustNotQuery = q.bool().mustNot()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustNotQuery = boolQueryBuild.bool().mustNot()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustNotQuery.size shouldBe 0
     }
 
     test("should 쿼리에서 terms 쿼리 생성이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 shouldQuery {
                     queries[
                         termsQuery(
@@ -287,19 +280,18 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val shouldQuery = q.bool().should()
 
-        val boolQueryBuild = boolQuery.build()
-        val shouldQuery = boolQueryBuild.bool().should()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         shouldQuery.size shouldBe 2
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("should 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 shouldQuery {
                     queries[
                         termsQuery(
@@ -321,11 +313,10 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val shouldQuery = q.bool().should()
 
-        val boolQueryBuild = boolQuery.build()
-        val shouldQuery = boolQueryBuild.bool().should()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         shouldQuery.size shouldBe 2
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
@@ -334,8 +325,8 @@ class TermsQueryTest: FunSpec({
     }
 
     test("should 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 shouldQuery {
                     queries[
                         termsQuery(
@@ -349,17 +340,16 @@ class TermsQueryTest: FunSpec({
                     ]
                 }
             }
+        }
+        val shouldQuery = q.bool().should()
 
-        val boolQueryBuild = boolQuery.build()
-        val shouldQuery = boolQueryBuild.bool().should()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         shouldQuery.size shouldBe 0
     }
 
     test("terms 쿼리에 boost 설정시 적용이 되어야함") {
-        val boolQuery = Query.Builder()
-            .boolQuery {
+        val q = query {
+            boolQuery {
                 mustQuery {
                     termsQuery(
                         field = "a",
@@ -368,31 +358,30 @@ class TermsQueryTest: FunSpec({
                     )
                 }
             }
+        }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().boost() shouldBe 2.5F
     }
 
     test("terms 쿼리에 _name이 설정되면 terms.queryName에 반영되어야함") {
-        val boolQuery = Query.Builder().boolQuery {
-            mustQuery {
-                termsQuery(
-                    field = "a",
-                    values = listOf("1111", "2222"),
-                    _name = "named"
-                )
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    termsQuery(
+                        field = "a",
+                        values = listOf("1111", "2222"),
+                        _name = "named"
+                    )
+                }
             }
         }
+        val mustQuery = q.bool().must()
 
-        val boolQueryBuild = boolQuery.build()
-        val mustQuery = boolQueryBuild.bool().must()
-
-        boolQueryBuild.isBool shouldBe true
+        q.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().queryName() shouldBe "named"


### PR DESCRIPTION
- Updated BoolQueryTest to utilize the new query DSL for constructing bool queries.
- Refactored SubQueryBuildersTest to replace Query.Builder() with the new query DSL.
- Modified ExistsQueryTest to implement the new query DSL for exists queries.
- Changed RangeQueryTest to use the new query DSL for range queries.
- Updated TermQueryTest to adopt the new query DSL for term queries.
- Refactored TermsQueryTest to utilize the new query DSL for terms queries.