### PR TITLE
feat(fulltext): add match_phrase, match_phrase_prefix, and multi_matc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,22 @@
 
 이 라이브러리는 동적인 조건에 따라 쿼리가 생성되거나 제외되어야 하는 실무적인 요구사항을 쉽게 해결하는 데 중점을 둡니다.
 
+## 📚 목차
+
+- [✨ 주요 특징](#-주요-특징)
+- [⚡ 빠른 시작](#-빠른-시작)
+- [🚀 사용 방법](#-사용-방법)
+  - [1. 기본 Bool 쿼리](#1-기본-bool-쿼리)
+  - [2. 단일 쿼리와 여러 쿼리](#2-단일-쿼리와-여러-쿼리)
+  - [3. 동적 쿼리 제외](#3-동적-쿼리-제외)
+  - [4. match_bool_prefix 쿼리](#4-match_bool_prefix-쿼리)
+  - [5. match_phrase 구문 검색](#5-match_phrase-구문-검색)
+  - [6. match_phrase_prefix 구문 접두어](#6-match_phrase_prefix-구문-접두어)
+- [7. 멀티필드 구문 검색 (multi_match type=phrase)](#7-멀티필드-구문-검색-multi_match-typephrase)
+- [⚙️ 성능/튜닝 팁](#-성능튜닝-팁)
+- [🛠️ 프로젝트 구조](#️-프로젝트-구조)
+- [📜 라이선스](#-라이선스)
+
 ## ✨ 주요 특징
 
 - **직관적인 DSL**: 복잡한 JSON 구조 대신 코틀린다운 코드로 쿼리를 작성할 수 있습니다.
@@ -13,6 +29,43 @@
 - **타입 안정성**: 코틀린 컴파일러의 지원을 받아 잘못된 쿼리 구조를 컴파일 시점에 방지합니다.
 - **혼용 방지**: 단일 쿼리와 여러 쿼리를 묶는 `queries[...]` 구문을 혼용하여 발생할 수 있는 실수를 런타임 예외를 통해 방지합니다.
 - **확장성**: 새로운 쿼리 타입을 쉽게 추가하고 기존 DSL에 통합할 수 있는 구조입니다.
+- **구문 검색 지원**: `match_phrase`, `match_phrase_prefix`, `multi_match(type=phrase)`를 통해 순서·근접성 기반 검색과 접두어 구문 검색을 간결하게 작성합니다.
+
+## ⚡ 빠른 시작
+
+1) 빌드/테스트
+
+```bash
+./gradlew clean build
+```
+
+2) 로컬 배포(선택)
+
+```bash
+./gradlew publishToMavenLocal
+```
+
+3) 최소 예제
+
+```kotlin
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.*
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext.*
+
+val q: Query = query {
+    boolQuery {
+        mustQuery {
+            queries[
+                matchPhraseQuery("message", "this is a test"),
+                matchPhrasePrefixQuery("path", "/api/ad"),
+                multiMatchPhraseQuery("quick brown fox", listOf("title^2", "body"))
+            ]
+        }
+    }
+}
+```
 
 ## 🚀 사용 방법
 
@@ -247,6 +300,181 @@ val q3 = query {
 | `fuzzyRewrite` | String? | 퍼지 rewrite 전략(마지막 prefix에는 미적용) |
 | `boost` | Float? | 가중치 |
 | `_name` | String? | 쿼리 식별용 이름 |
+
+### 5. match_phrase 구문 검색
+
+문구의 순서와 근접성을 따르는 구문 검색입니다. `slop`으로 허용 간격을 조정할 수 있고, `zeroTermsQuery`로 불용어만 남는 경우의 동작을 정의합니다. `query`가 null/빈 문자열이면 동적으로 제외됩니다.
+
+```kotlin
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext.matchPhraseQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
+
+val q = query {
+    boolQuery {
+        mustQuery {
+            matchPhraseQuery(
+                field = "message",
+                query = "this is a test",
+                slop = 0,
+                analyzer = "standard",
+                zeroTermsQuery = ZeroTermsQuery.None
+            )
+        }
+    }
+}
+```
+
+등가 JSON 예시:
+
+```json
+{
+  "query": {
+    "match_phrase": {
+      "message": {
+        "query": "this is a test",
+        "slop": 0,
+        "analyzer": "standard"
+      }
+    }
+  }
+}
+```
+
+예제 바로가기: [5. match_phrase 구문 검색](#5-match_phrase-구문-검색)
+
+옵션 표
+
+| 옵션 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `field` | String | - | 대상 필드(필수) |
+| `query` | String? | - | 검색어; null/빈 문자열이면 제외 |
+| `analyzer` | String? | 필드 검색 분석기 | 질의어 분석기 지정 |
+| `slop` | Int? | 0 | 허용 간격(자리바꿈은 2로 계산) |
+| `zeroTermsQuery` | ZeroTermsQuery? | None | 토큰 소거 시 동작(None/All) |
+| `boost` | Float? | 1.0 | 가중치 |
+| `_name` | String? | - | 쿼리 식별용 이름 |
+
+### 6. match_phrase_prefix 구문 접두어
+
+구문 순서를 유지하면서 마지막 토큰만 접두어로 확장합니다. 경로/식별자 등에도 유용합니다.
+
+```kotlin
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext.matchPhrasePrefix
+
+val q = query {
+    matchPhrasePrefix(
+        field = "path",
+        query = "/api/ad"
+    )
+}
+```
+
+옵션: `analyzer`, `slop`, `zeroTermsQuery`, `maxExpansions`, `boost`, `_name`
+
+등가 JSON 예시:
+
+```json
+{
+  "query": {
+    "match_phrase_prefix": {
+      "path": {
+        "query": "/api/ad",
+        "slop": 0
+      }
+    }
+  }
+}
+```
+
+예제 바로가기: [6. match_phrase_prefix 구문 접두어](#6-match_phrase_prefix-구문-접두어)
+
+옵션 표
+
+| 옵션 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `field` | String | - | 대상 필드(필수) |
+| `query` | String? | - | 검색어; null/빈 문자열이면 제외 |
+| `analyzer` | String? | 필드 검색 분석기 | 질의어 분석기 지정 |
+| `slop` | Int? | 0 | 구문 허용 간격 |
+| `zeroTermsQuery` | ZeroTermsQuery? | None | 토큰 소거 시 동작(None/All) |
+| `maxExpansions` | Int? | 50 | 접두어 확장 최대치 |
+| `boost` | Float? | 1.0 | 가중치 |
+| `_name` | String? | - | 쿼리 식별용 이름 |
+
+### 7. 멀티필드 구문 검색 (multi_match type=phrase)
+
+여러 필드에 구문 의미로 검색합니다. 필드 가중치는 `^`로 지정하세요(`title^2`). `query`가 비거나 `fields`가 비면 동적으로 제외됩니다.
+
+```kotlin
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext.multiMatchPhrase
+
+val q = query {
+    multiMatchPhrase(
+        query = "quick brown fox",
+        fields = listOf("title^2", "body"),
+        slop = 2
+    )
+}
+```
+
+등가 JSON 예시:
+
+```json
+{
+  "query": {
+    "multi_match": {
+      "query": "quick brown fox",
+      "type": "phrase",
+      "fields": ["title^2", "body"],
+      "slop": 2
+    }
+  }
+}
+```
+
+## ⚙️ 성능/튜닝 팁
+
+- 분석기 선택: 검색 대상이 자연어면 `text` + 언어별 분석기(`standard`, `nori` 등)를, 경로/식별자/코드면 `keyword` 또는 `analyzer = "keyword"`를 고려하세요. 불용어(stop)로 토큰이 모두 제거될 수 있으므로 필요 시 `zeroTermsQuery = All`을 사용합니다.
+- Slop 가이드: `slop = 0`은 정확한 구문 일치입니다. 작은 오탈/간격 허용은 `1~2`를 권장합니다. 자리바꿈(transposed terms)은 슬롭 2로 계산됩니다. 큰 값은 후보 증가로 성능 저하와 정밀도 하락을 유발할 수 있습니다.
+- Prefix 주의: `match_phrase_prefix`/`match_bool_prefix`는 접두어 확장으로 비용이 커질 수 있습니다. `maxExpansions`로 제한하고, 대규모 자동완성은 인덱스 측면 최적화(`edge_ngram` 분석기, `index_prefixes`)를 검토하세요.
+- 매핑 최적화(참고): 구문/접두어 성능이 중요하면 텍스트 필드에 사전 계산을 켭니다.
+  - `index_phrases: true` → 구문 검색 가속화
+  - `index_prefixes` → 접두어 검색 가속화
+
+예시 매핑(개념):
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text",
+        "index_phrases": true,
+        "index_prefixes": { "min_chars": 1, "max_chars": 10 }
+      }
+    }
+  }
+}
+```
+
+예제 바로가기: [7. 멀티필드 구문 검색](#7-멀티필드-구문-검색-multi_match-typephrase)
+
+옵션 표
+
+| 옵션 | 타입 | 기본값 | 설명 |
+|---|---|---|---|
+| `query` | String? | - | 검색어; null/빈 문자열이면 제외 |
+| `fields` | List<String> | - | 대상 필드 목록(비어있으면 제외) |
+| `analyzer` | String? | 필드 검색 분석기 | 질의어 분석기 지정 |
+| `slop` | Int? | 0 | 구문 허용 간격 |
+| `zeroTermsQuery` | ZeroTermsQuery? | None | 토큰 소거 시 동작(None/All) |
+| `boost` | Float? | 1.0 | 가중치 |
+| `_name` | String? | - | 쿼리 식별용 이름 |
 
 ## 🛠️ 프로젝트 구조
 

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhrasePrefixQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhrasePrefixQuery.kt
@@ -1,0 +1,63 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchPhrasePrefixQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
+import co.elastic.clients.util.ObjectBuilder
+
+/**
+ * match_phrase_prefix 쿼리 DSL 빌더
+ * - 마지막 토큰만 접두어 확장하며 구문 순서는 유지
+ * - query가 null/blank면 생성하지 않음
+ */
+fun Query.Builder.matchPhrasePrefix(
+    field: String,
+    query: String?,
+    analyzer: String? = null,
+    slop: Int? = null,
+    zeroTermsQuery: ZeroTermsQuery? = null,
+    maxExpansions: Int? = null,
+    boost: Float? = null,
+    _name: String? = null
+): ObjectBuilder<Query> {
+    if (query.isNullOrEmpty()) return this
+
+    return this.matchPhrasePrefix { b ->
+        b.field(field)
+            .query(query)
+        analyzer?.let { b.analyzer(it) }
+        slop?.let { b.slop(it) }
+        zeroTermsQuery?.let { b.zeroTermsQuery(it) }
+        maxExpansions?.let { b.maxExpansions(it) }
+        boost?.let { b.boost(it) }
+        _name?.let { b.queryName(it) }
+        b
+    }
+}
+
+fun matchPhrasePrefixQuery(
+    field: String,
+    query: String?,
+    analyzer: String? = null,
+    slop: Int? = null,
+    zeroTermsQuery: ZeroTermsQuery? = null,
+    maxExpansions: Int? = null,
+    boost: Float? = null,
+    _name: String? = null
+): Query? {
+    return if (query.isNullOrEmpty()) {
+        null
+    } else {
+        val b = MatchPhrasePrefixQuery.Builder()
+            .field(field)
+            .query(query)
+        analyzer?.let { b.analyzer(it) }
+        slop?.let { b.slop(it) }
+        zeroTermsQuery?.let { b.zeroTermsQuery(it) }
+        maxExpansions?.let { b.maxExpansions(it) }
+        boost?.let { b.boost(it) }
+        _name?.let { b.queryName(it) }
+        b.build()._toQuery()
+    }
+}
+

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhraseQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhraseQuery.kt
@@ -1,0 +1,63 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import co.elastic.clients.elasticsearch._types.query_dsl.MatchPhraseQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
+import co.elastic.clients.util.ObjectBuilder
+
+/**
+ * match_phrase 쿼리 DSL 빌더
+ * - 입력 문자열이 null/blank이면 쿼리를 생성하지 않음(null 반환 또는 no-op)
+ * - 옵션: analyzer, slop, zeroTermsQuery, boost, _name
+ */
+fun Query.Builder.matchPhrase(
+    field: String,
+    query: String?,
+    analyzer: String? = null,
+    slop: Int? = null,
+    zeroTermsQuery: ZeroTermsQuery? = null,
+    boost: Float? = null,
+    _name: String? = null
+): ObjectBuilder<Query> {
+    if (query.isNullOrEmpty()) {
+        return this
+    }
+
+    return this.matchPhrase { b ->
+        b.field(field)
+            .query(query)
+        analyzer?.let { b.analyzer(it) }
+        slop?.let { b.slop(it) }
+        zeroTermsQuery?.let { b.zeroTermsQuery(it) }
+        boost?.let { b.boost(it) }
+        _name?.let { b.queryName(it) }
+        b
+    }
+}
+
+fun matchPhraseQuery(
+    field: String,
+    query: String?,
+    analyzer: String? = null,
+    slop: Int? = null,
+    zeroTermsQuery: ZeroTermsQuery? = null,
+    boost: Float? = null,
+    _name: String? = null
+): Query? {
+    return if (query.isNullOrEmpty()) {
+        null
+    } else {
+        val builder = MatchPhraseQuery.Builder()
+            .field(field)
+            .query(query)
+
+        analyzer?.let { builder.analyzer(it) }
+        slop?.let { builder.slop(it) }
+        zeroTermsQuery?.let { builder.zeroTermsQuery(it) }
+        boost?.let { builder.boost(it) }
+        _name?.let { builder.queryName(it) }
+
+        builder.build()._toQuery()
+    }
+}
+

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchPhraseQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchPhraseQuery.kt
@@ -1,0 +1,61 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import co.elastic.clients.elasticsearch._types.query_dsl.MultiMatchQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
+import co.elastic.clients.util.ObjectBuilder
+
+/**
+ * multi_match (type=phrase) DSL 빌더
+ * - 단일 질의어를 여러 필드에 구문(phrase) 의미로 적용
+ * - query가 null/blank이거나 fields가 비면 생성하지 않음
+ */
+fun Query.Builder.multiMatchPhrase(
+    query: String?,
+    fields: List<String>,
+    analyzer: String? = null,
+    slop: Int? = null,
+    zeroTermsQuery: ZeroTermsQuery? = null,
+    boost: Float? = null,
+    _name: String? = null
+): ObjectBuilder<Query> {
+    if (query.isNullOrEmpty() || fields.isEmpty()) return this
+
+    return this.multiMatch { b ->
+        b.query(query)
+            .fields(fields)
+            .type(TextQueryType.Phrase)
+        analyzer?.let { b.analyzer(it) }
+        slop?.let { b.slop(it) }
+        zeroTermsQuery?.let { b.zeroTermsQuery(it) }
+        boost?.let { b.boost(it) }
+        _name?.let { b.queryName(it) }
+        b
+    }
+}
+
+fun multiMatchPhraseQuery(
+    query: String?,
+    fields: List<String>,
+    analyzer: String? = null,
+    slop: Int? = null,
+    zeroTermsQuery: ZeroTermsQuery? = null,
+    boost: Float? = null,
+    _name: String? = null
+): Query? {
+    return if (query.isNullOrEmpty() || fields.isEmpty()) {
+        null
+    } else {
+        val b = MultiMatchQuery.Builder()
+            .query(query)
+            .fields(fields)
+            .type(TextQueryType.Phrase)
+        analyzer?.let { b.analyzer(it) }
+        slop?.let { b.slop(it) }
+        zeroTermsQuery?.let { b.zeroTermsQuery(it) }
+        boost?.let { b.boost(it) }
+        _name?.let { b.queryName(it) }
+        b.build()._toQuery()
+    }
+}

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhrasePrefixQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhrasePrefixQueryTest.kt
@@ -1,0 +1,71 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.filterQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustNotQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.shouldQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class MatchPhrasePrefixQueryTest : FunSpec({
+
+    test("최상위 match_phrase_prefix 쿼리 생성") {
+        val q = query {
+            matchPhrasePrefix(
+                field = "path",
+                query = "/api/ad"
+            )
+        }
+
+        q.isMatchPhrasePrefix shouldBe true
+        q.matchPhrasePrefix().field() shouldBe "path"
+        q.matchPhrasePrefix().query() shouldBe "/api/ad"
+    }
+
+    test("must/filter/mustNot/should에서 생성/생략 동작") {
+        val q = query {
+            boolQuery {
+                mustQuery { queries[ matchPhrasePrefixQuery("a", "quick bro") ] }
+                filterQuery { queries[ matchPhrasePrefixQuery("b", "fox ju") ] }
+                mustNotQuery { queries[ matchPhrasePrefixQuery("c", "over th") ] }
+                shouldQuery { queries[ matchPhrasePrefixQuery("d", "lazy do") ] }
+            }
+        }
+
+        q.bool().must().first().matchPhrasePrefix().field() shouldBe "a"
+        q.bool().filter().first().matchPhrasePrefix().field() shouldBe "b"
+        q.bool().mustNot().first().matchPhrasePrefix().field() shouldBe "c"
+        q.bool().should().first().matchPhrasePrefix().field() shouldBe "d"
+    }
+
+    test("옵션 slop/zero_terms_query/max_expansions/boost/_name 적용") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    matchPhrasePrefixQuery(
+                        field = "title",
+                        query = "kotlin cor",
+                        slop = 2,
+                        zeroTermsQuery = ZeroTermsQuery.None,
+                        maxExpansions = 10,
+                        boost = 1.2f,
+                        _name = "mpp"
+                    )
+                }
+            }
+        }
+
+        val mpp = q.bool().must().first().matchPhrasePrefix()
+        mpp.field() shouldBe "title"
+        mpp.query() shouldBe "kotlin cor"
+        mpp.slop() shouldBe 2
+        mpp.zeroTermsQuery() shouldBe ZeroTermsQuery.None
+        mpp.maxExpansions() shouldBe 10
+        mpp.boost() shouldBe 1.2f
+        mpp.queryName() shouldBe "mpp"
+    }
+})
+

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhraseQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhraseQueryTest.kt
@@ -1,0 +1,87 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.filterQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustNotQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.shouldQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class MatchPhraseQueryTest : FunSpec({
+
+    test("must 쿼리에서 match_phrase 쿼리 생성/스킵 동작") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    queries[
+                        matchPhraseQuery("message", "this is a test"),
+                        matchPhraseQuery("skip_null", null),
+                        matchPhraseQuery("skip_blank", "")
+                    ]
+                }
+            }
+        }
+
+        val must = q.bool().must()
+        q.isBool shouldBe true
+        must.size shouldBe 1
+        must.first().isMatchPhrase shouldBe true
+        must.first().matchPhrase().field() shouldBe "message"
+        must.first().matchPhrase().query() shouldBe "this is a test"
+    }
+
+    test("filter/mustNot/should 에서도 match_phrase 쿼리 동작") {
+        val q = query {
+            boolQuery {
+                filterQuery {
+                    queries[ matchPhraseQuery("f", "alpha beta") ]
+                }
+                mustNotQuery {
+                    queries[ matchPhraseQuery("mn", "gamma delta") ]
+                }
+                shouldQuery {
+                    queries[ matchPhraseQuery("s", "quick brown fox") ]
+                }
+            }
+        }
+
+        q.bool().filter().size shouldBe 1
+        q.bool().filter().first().matchPhrase().field() shouldBe "f"
+
+        q.bool().mustNot().size shouldBe 1
+        q.bool().mustNot().first().matchPhrase().field() shouldBe "mn"
+
+        q.bool().should().size shouldBe 1
+        q.bool().should().first().matchPhrase().field() shouldBe "s"
+    }
+
+    test("match_phrase 옵션: analyzer, slop, zero_terms_query, boost, _name 적용") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    matchPhraseQuery(
+                        field = "title",
+                        query = "quick brown fox",
+                        analyzer = "standard",
+                        slop = 2,
+                        zeroTermsQuery = ZeroTermsQuery.All,
+                        boost = 1.5F,
+                        _name = "phrase_query"
+                    )
+                }
+            }
+        }
+
+        val mp = q.bool().must().first().matchPhrase()
+        mp.field() shouldBe "title"
+        mp.query() shouldBe "quick brown fox"
+        mp.analyzer() shouldBe "standard"
+        mp.slop() shouldBe 2
+        mp.zeroTermsQuery() shouldBe ZeroTermsQuery.All
+        mp.boost() shouldBe 1.5F
+        mp.queryName() shouldBe "phrase_query"
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchPhraseQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchPhraseQueryTest.kt
@@ -1,0 +1,77 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType
+import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class MultiMatchPhraseQueryTest : FunSpec({
+
+    test("최상위 multi_match(type=phrase) 쿼리 생성") {
+        val q = query {
+            multiMatchPhrase(
+                query = "quick brown fox",
+                fields = listOf("title^2", "body")
+            )
+        }
+
+        q.isMultiMatch shouldBe true
+        val mm = q.multiMatch()
+        mm.query() shouldBe "quick brown fox"
+        mm.type() shouldBe TextQueryType.Phrase
+        mm.fields().size shouldBe 2
+        mm.fields().contains("title^2") shouldBe true
+        mm.fields().contains("body") shouldBe true
+    }
+
+    test("must 절에서 multi_match phrase 생성/생략 동작") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    queries[
+                        multiMatchPhraseQuery("kotlin coroutine", listOf("title", "desc")),
+                        multiMatchPhraseQuery(null, listOf("title")),
+                        multiMatchPhraseQuery("", listOf("title")),
+                        multiMatchPhraseQuery("text", emptyList())
+                    ]
+                }
+            }
+        }
+
+        val must = q.bool().must()
+        must.size shouldBe 1
+        val mm = must.first().multiMatch()
+        mm.type() shouldBe TextQueryType.Phrase
+        mm.query() shouldBe "kotlin coroutine"
+        mm.fields().size shouldBe 2
+    }
+
+    test("옵션: analyzer/slop/zero_terms_query/boost/_name 적용") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    multiMatchPhraseQuery(
+                        query = "quick brown fox",
+                        fields = listOf("title^2", "body"),
+                        analyzer = "standard",
+                        slop = 3,
+                        zeroTermsQuery = ZeroTermsQuery.All,
+                        boost = 1.4f,
+                        _name = "mm_phrase"
+                    )
+                }
+            }
+        }
+
+        val mm = q.bool().must().first().multiMatch()
+        mm.type() shouldBe TextQueryType.Phrase
+        mm.analyzer() shouldBe "standard"
+        mm.slop() shouldBe 3
+        mm.zeroTermsQuery() shouldBe ZeroTermsQuery.All
+        mm.boost() shouldBe 1.4f
+        mm.queryName() shouldBe "mm_phrase"
+    }
+})


### PR DESCRIPTION
…h(type=phrase) DSLs with tests\n\n- match_phrase: analyzer, slop, zeroTermsQuery, boost, _name\n- match_phrase_prefix: analyzer, slop, zeroTermsQuery, maxExpansions, boost, _name\n- multi_match(type=phrase): analyzer, slop, zeroTermsQuery, boost; omit when query/fields empty\n- tests: creation/omission/options across bool clauses\n\ndocs(readme): add examples, JSON equivalents, option tables, quick start, and performance tuning tips for phrase queries