### PR TITLE
Refactor and consolidate query tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ bin/
 .DS_Store
 /GEMINI.md
 /AGENTS.md
+CLAUDE.md

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/BoolQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/BoolQueryTest.kt
@@ -10,10 +10,10 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class BoolQueryTest: FunSpec({
+class BoolQueryTest : FunSpec({
 
     test("bool에 filter query가 추가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     termQuery(
@@ -24,15 +24,15 @@ class BoolQueryTest: FunSpec({
             }
         }
 
-        q.isBool shouldBe true
-        q.bool().filter().size shouldBe 1
-        q.bool().must().size shouldBe 0
-        q.bool().mustNot().size shouldBe 0
-        q.bool().should().size shouldBe 0
+        query.isBool shouldBe true
+        query.bool().filter().size shouldBe 1
+        query.bool().must().size shouldBe 0
+        query.bool().mustNot().size shouldBe 0
+        query.bool().should().size shouldBe 0
     }
 
     test("bool에 must query가 추가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     termQuery(
@@ -43,15 +43,15 @@ class BoolQueryTest: FunSpec({
             }
         }
 
-        q.isBool shouldBe true
-        q.bool().filter().size shouldBe 0
-        q.bool().must().size shouldBe 1
-        q.bool().mustNot().size shouldBe 0
-        q.bool().should().size shouldBe 0
+        query.isBool shouldBe true
+        query.bool().filter().size shouldBe 0
+        query.bool().must().size shouldBe 1
+        query.bool().mustNot().size shouldBe 0
+        query.bool().should().size shouldBe 0
     }
 
     test("bool에 mustNot query가 추가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustNotQuery {
                     termQuery(
@@ -62,15 +62,15 @@ class BoolQueryTest: FunSpec({
             }
         }
 
-        q.isBool shouldBe true
-        q.bool().filter().size shouldBe 0
-        q.bool().must().size shouldBe 0
-        q.bool().mustNot().size shouldBe 1
-        q.bool().should().size shouldBe 0
+        query.isBool shouldBe true
+        query.bool().filter().size shouldBe 0
+        query.bool().must().size shouldBe 0
+        query.bool().mustNot().size shouldBe 1
+        query.bool().should().size shouldBe 0
     }
 
     test("bool에 should query가 추가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 shouldQuery {
                     termQuery(
@@ -81,15 +81,15 @@ class BoolQueryTest: FunSpec({
             }
         }
 
-        q.isBool shouldBe true
-        q.bool().filter().size shouldBe 0
-        q.bool().must().size shouldBe 0
-        q.bool().mustNot().size shouldBe 0
-        q.bool().should().size shouldBe 1
+        query.isBool shouldBe true
+        query.bool().filter().size shouldBe 0
+        query.bool().must().size shouldBe 0
+        query.bool().mustNot().size shouldBe 0
+        query.bool().should().size shouldBe 1
     }
 
     test("bool에 filter, must, mustNot, should query가 추가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     termQuery(
@@ -118,15 +118,15 @@ class BoolQueryTest: FunSpec({
             }
         }
 
-        q.isBool shouldBe true
-        q.bool().filter().size shouldBe 1
-        q.bool().must().size shouldBe 1
-        q.bool().mustNot().size shouldBe 1
-        q.bool().should().size shouldBe 1
+        query.isBool shouldBe true
+        query.bool().filter().size shouldBe 1
+        query.bool().must().size shouldBe 1
+        query.bool().mustNot().size shouldBe 1
+        query.bool().should().size shouldBe 1
     }
 
     test("bool에 minimumShouldMatch, boost가 추가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     termQuery(
@@ -157,12 +157,12 @@ class BoolQueryTest: FunSpec({
             }
         }
 
-        q.isBool shouldBe true
-        q.bool().filter().size shouldBe 1
-        q.bool().must().size shouldBe 1
-        q.bool().mustNot().size shouldBe 1
-        q.bool().should().size shouldBe 1
-        q.bool().minimumShouldMatch() shouldBe "2"
-        q.bool().boost() shouldBe 2.0F
+        query.isBool shouldBe true
+        query.bool().filter().size shouldBe 1
+        query.bool().must().size shouldBe 1
+        query.bool().mustNot().size shouldBe 1
+        query.bool().should().size shouldBe 1
+        query.bool().minimumShouldMatch() shouldBe "2"
+        query.bool().boost() shouldBe 2.0F
     }
 })

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/BoostingQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/BoostingQueryTest.kt
@@ -67,10 +67,8 @@ class BoostingQueryTest : FunSpec({
         }
 
         boostingQuery.isBoosting shouldBe true
-        // positive절은 bool query로 감싸져야 함
         boostingQuery.boosting().positive().isBool shouldBe true
         boostingQuery.boosting().positive().bool().must().size shouldBe 2
-        // negative절은 단일 쿼리이므로 bool query로 감싸지지 않아야 함
         boostingQuery.boosting().negative().isTerm shouldBe true
         boostingQuery.boosting().negativeBoost() shouldBe 0.2
     }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQueryTest.kt
@@ -16,7 +16,7 @@ import io.kotest.matchers.shouldBe
 class ConstantScoreQueryTest : FunSpec({
 
     test("최상위 constant_score 쿼리가 올바르게 생성되어야 한다") {
-        val q = query {
+        val query = query {
             constantScoreQuery {
                 filterQuery {
                     termQuery(field = "brand", value = "Samsung")
@@ -26,16 +26,16 @@ class ConstantScoreQueryTest : FunSpec({
             }
         }
 
-        q.isConstantScore shouldBe true
-        q.constantScore().filter().isTerm shouldBe true
-        q.constantScore().filter().term().field() shouldBe "brand"
-        q.constantScore().filter().term().value().stringValue() shouldBe "Samsung"
-        q.constantScore().boost() shouldBe 10.0f
-        q.constantScore().queryName() shouldBe "named"
+        query.isConstantScore shouldBe true
+        query.constantScore().filter().isTerm shouldBe true
+        query.constantScore().filter().term().field() shouldBe "brand"
+        query.constantScore().filter().term().value().stringValue() shouldBe "Samsung"
+        query.constantScore().boost() shouldBe 10.0f
+        query.constantScore().queryName() shouldBe "named"
     }
 
     test("constant_score는 must, filter, mustNot 절에서 사용될 수 있다") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     constantScoreQuery {
@@ -55,12 +55,12 @@ class ConstantScoreQueryTest : FunSpec({
             }
         }
 
-        q.bool().must().size shouldBe 1
-        q.bool().filter().size shouldBe 1
-        q.bool().mustNot().size shouldBe 1
-        q.bool().must().first().constantScore().filter().term().field() shouldBe "brand"
-        q.bool().filter().first().constantScore().filter().term().field() shouldBe "category"
-        q.bool().mustNot().first().constantScore().filter().term().field() shouldBe "status"
+        query.bool().must().size shouldBe 1
+        query.bool().filter().size shouldBe 1
+        query.bool().mustNot().size shouldBe 1
+        query.bool().must().first().constantScore().filter().term().field() shouldBe "brand"
+        query.bool().filter().first().constantScore().filter().term().field() shouldBe "category"
+        query.bool().mustNot().first().constantScore().filter().term().field() shouldBe "status"
     }
 
     test("필터가 비어있을 때 최상위 constant_score는 건너뛰어야 한다") {
@@ -76,7 +76,7 @@ class ConstantScoreQueryTest : FunSpec({
     }
 
     test("bool 절 내부의 constant_score는 필터가 비어있을 때 건너뛰어야 한다") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     constantScoreQuery {
@@ -88,11 +88,11 @@ class ConstantScoreQueryTest : FunSpec({
             }
         }
 
-        q.bool().must().size shouldBe 0
+        query.bool().must().size shouldBe 0
     }
 
     test("queries를 사용하는 필터 블록은 bool 쿼리로 래핑되어야 한다") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     constantScoreQuery {
@@ -107,7 +107,7 @@ class ConstantScoreQueryTest : FunSpec({
             }
         }
 
-        val csFilter = q.bool().filter().first().constantScore().filter()
+        val csFilter = query.bool().filter().first().constantScore().filter()
         csFilter.isBool shouldBe true
         csFilter.bool().must().size shouldBe 2
         csFilter.bool().must().any { it.term().field() == "brand" } shouldBe true
@@ -115,7 +115,7 @@ class ConstantScoreQueryTest : FunSpec({
     }
 
     test("constant_score 필터는 복잡한 bool 쿼리를 포함할 수 있다") {
-        val q = query {
+        val query = query {
             constantScoreQuery {
                 filterQuery {
                     boolQuery {
@@ -134,8 +134,8 @@ class ConstantScoreQueryTest : FunSpec({
             }
         }
 
-        q.isConstantScore shouldBe true
-        val cs = q.constantScore()
+        query.isConstantScore shouldBe true
+        val cs = query.constantScore()
         cs.boost() shouldBe 2.0f
 
         val filter = cs.filter()
@@ -149,7 +149,7 @@ class ConstantScoreQueryTest : FunSpec({
     }
 
     test("should 절의 constant_score는 점수를 높인다") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     termQuery("content", "search")
@@ -165,8 +165,8 @@ class ConstantScoreQueryTest : FunSpec({
             }
         }
 
-        q.isBool shouldBe true
-        val bool = q.bool()
+        query.isBool shouldBe true
+        val bool = query.bool()
         bool.must().size shouldBe 1
         bool.must().first().term().field() shouldBe "content"
         bool.should().size shouldBe 1

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchBoolPrefixQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchBoolPrefixQueryTest.kt
@@ -13,20 +13,20 @@ import io.kotest.matchers.shouldBe
 class MatchBoolPrefixQueryTest : FunSpec({
 
     test("최상위 match_bool_prefix 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             matchBoolPrefix(
                 field = "message",
                 query = "quick brown f"
             )
         }
 
-        q.isMatchBoolPrefix shouldBe true
-        q.matchBoolPrefix().field() shouldBe "message"
-        q.matchBoolPrefix().query() shouldBe "quick brown f"
+        query.isMatchBoolPrefix shouldBe true
+        query.matchBoolPrefix().field() shouldBe "message"
+        query.matchBoolPrefix().query() shouldBe "quick brown f"
     }
 
     test("must 쿼리에서 match_bool_prefix 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -37,15 +37,15 @@ class MatchBoolPrefixQueryTest : FunSpec({
             }
         }
 
-        val must = q.bool().must()
-        q.isBool shouldBe true
+        val must = query.bool().must()
+        query.isBool shouldBe true
         must.size shouldBe 2
         must.filter { it.isMatchBoolPrefix }.find { it.matchBoolPrefix().field() == "title" }?.matchBoolPrefix()?.query() shouldBe "quick brow"
         must.filter { it.isMatchBoolPrefix }.find { it.matchBoolPrefix().field() == "desc" }?.matchBoolPrefix()?.query() shouldBe "kotlin dsl"
     }
 
     test("must 쿼리에서 query가 null/빈 문자열이면 제외되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -57,15 +57,15 @@ class MatchBoolPrefixQueryTest : FunSpec({
             }
         }
 
-        val must = q.bool().must()
-        q.isBool shouldBe true
+        val must = query.bool().must()
+        query.isBool shouldBe true
         must.size shouldBe 1
         must.first().matchBoolPrefix().field() shouldBe "c"
         must.first().matchBoolPrefix().query() shouldBe "hello w"
     }
 
     test("filter/mustNot/should 절에서도 동일하게 동작해야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     queries[
@@ -85,9 +85,9 @@ class MatchBoolPrefixQueryTest : FunSpec({
             }
         }
 
-        val filter = q.bool().filter()
-        val mustNot = q.bool().mustNot()
-        val should = q.bool().should()
+        val filter = query.bool().filter()
+        val mustNot = query.bool().mustNot()
+        val should = query.bool().should()
 
         filter.size shouldBe 1
         mustNot.size shouldBe 1
@@ -99,7 +99,7 @@ class MatchBoolPrefixQueryTest : FunSpec({
     }
 
     test("옵션: operator, minimum_should_match, analyzer, boost, _name 적용 확인") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     matchBoolPrefixQuery(
@@ -120,7 +120,7 @@ class MatchBoolPrefixQueryTest : FunSpec({
             }
         }
 
-        val qb = q.bool().must().first().matchBoolPrefix()
+        val qb = query.bool().must().first().matchBoolPrefix()
         qb.field() shouldBe "title"
         qb.query() shouldBe "quick brown f"
         qb.operator() shouldBe Operator.And

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhrasePrefixQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhrasePrefixQueryTest.kt
@@ -13,20 +13,20 @@ import io.kotest.matchers.shouldBe
 class MatchPhrasePrefixQueryTest : FunSpec({
 
     test("최상위 match_phrase_prefix 쿼리 생성") {
-        val q = query {
+        val query = query {
             matchPhrasePrefix(
                 field = "path",
                 query = "/api/ad"
             )
         }
 
-        q.isMatchPhrasePrefix shouldBe true
-        q.matchPhrasePrefix().field() shouldBe "path"
-        q.matchPhrasePrefix().query() shouldBe "/api/ad"
+        query.isMatchPhrasePrefix shouldBe true
+        query.matchPhrasePrefix().field() shouldBe "path"
+        query.matchPhrasePrefix().query() shouldBe "/api/ad"
     }
 
     test("must/filter/mustNot/should에서 생성/생략 동작") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery { queries[ matchPhrasePrefixQuery("a", "quick bro") ] }
                 filterQuery { queries[ matchPhrasePrefixQuery("b", "fox ju") ] }
@@ -35,14 +35,14 @@ class MatchPhrasePrefixQueryTest : FunSpec({
             }
         }
 
-        q.bool().must().first().matchPhrasePrefix().field() shouldBe "a"
-        q.bool().filter().first().matchPhrasePrefix().field() shouldBe "b"
-        q.bool().mustNot().first().matchPhrasePrefix().field() shouldBe "c"
-        q.bool().should().first().matchPhrasePrefix().field() shouldBe "d"
+        query.bool().must().first().matchPhrasePrefix().field() shouldBe "a"
+        query.bool().filter().first().matchPhrasePrefix().field() shouldBe "b"
+        query.bool().mustNot().first().matchPhrasePrefix().field() shouldBe "c"
+        query.bool().should().first().matchPhrasePrefix().field() shouldBe "d"
     }
 
     test("옵션 slop/zero_terms_query/max_expansions/boost/_name 적용") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     matchPhrasePrefixQuery(
@@ -58,7 +58,7 @@ class MatchPhrasePrefixQueryTest : FunSpec({
             }
         }
 
-        val mpp = q.bool().must().first().matchPhrasePrefix()
+        val mpp = query.bool().must().first().matchPhrasePrefix()
         mpp.field() shouldBe "title"
         mpp.query() shouldBe "kotlin cor"
         mpp.slop() shouldBe 2
@@ -68,4 +68,3 @@ class MatchPhrasePrefixQueryTest : FunSpec({
         mpp.queryName() shouldBe "mpp"
     }
 })
-

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhraseQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhraseQueryTest.kt
@@ -13,7 +13,7 @@ import io.kotest.matchers.shouldBe
 class MatchPhraseQueryTest : FunSpec({
 
     test("must 쿼리에서 match_phrase 쿼리 생성/스킵 동작") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -25,8 +25,8 @@ class MatchPhraseQueryTest : FunSpec({
             }
         }
 
-        val must = q.bool().must()
-        q.isBool shouldBe true
+        val must = query.bool().must()
+        query.isBool shouldBe true
         must.size shouldBe 1
         must.first().isMatchPhrase shouldBe true
         must.first().matchPhrase().field() shouldBe "message"
@@ -34,7 +34,7 @@ class MatchPhraseQueryTest : FunSpec({
     }
 
     test("filter/mustNot/should 에서도 match_phrase 쿼리 동작") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     queries[ matchPhraseQuery("f", "alpha beta") ]
@@ -48,18 +48,18 @@ class MatchPhraseQueryTest : FunSpec({
             }
         }
 
-        q.bool().filter().size shouldBe 1
-        q.bool().filter().first().matchPhrase().field() shouldBe "f"
+        query.bool().filter().size shouldBe 1
+        query.bool().filter().first().matchPhrase().field() shouldBe "f"
 
-        q.bool().mustNot().size shouldBe 1
-        q.bool().mustNot().first().matchPhrase().field() shouldBe "mn"
+        query.bool().mustNot().size shouldBe 1
+        query.bool().mustNot().first().matchPhrase().field() shouldBe "mn"
 
-        q.bool().should().size shouldBe 1
-        q.bool().should().first().matchPhrase().field() shouldBe "s"
+        query.bool().should().size shouldBe 1
+        query.bool().should().first().matchPhrase().field() shouldBe "s"
     }
 
     test("match_phrase 옵션: analyzer, slop, zero_terms_query, boost, _name 적용") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     matchPhraseQuery(
@@ -75,7 +75,7 @@ class MatchPhraseQueryTest : FunSpec({
             }
         }
 
-        val mp = q.bool().must().first().matchPhrase()
+        val mp = query.bool().must().first().matchPhrase()
         mp.field() shouldBe "title"
         mp.query() shouldBe "quick brown fox"
         mp.analyzer() shouldBe "standard"

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchQueryTest.kt
@@ -1,7 +1,6 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Operator
-import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.filterQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustNotQuery

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/ExistsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/ExistsQueryTest.kt
@@ -8,10 +8,10 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class ExistsQueryTest: FunSpec ({
+class ExistsQueryTest : FunSpec({
 
     test("must 쿼리에서 exists 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     existsQuery(
@@ -20,18 +20,17 @@ class ExistsQueryTest: FunSpec ({
                 }
             }
         }
-        val mustQuery = q.bool().must()
-        q.isBool shouldBe true
+        val mustQuery = query.bool().must()
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.first().isExists shouldBe true
         mustQuery.first().exists().field() shouldBe "a"
     }
 
     test("must 쿼리에서 exists 쿼리 생성시 field가 null이면 existsQuery가 빠져서 생성되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
-                    // 하위 쿼리에 여러개를 추가 해야 할경우 queries[...] 구문 사용
                     queries[
                         existsQuery(
                             field = null
@@ -44,16 +43,16 @@ class ExistsQueryTest: FunSpec ({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
-        mustQuery.size shouldBe 1 // termQuery만 추가되어 크기는 1
+        query.isBool shouldBe true
+        mustQuery.size shouldBe 1
         mustQuery.first().isTerm shouldBe true
         mustQuery.first().term().field() shouldBe "a"
     }
 
     test("exists 쿼리에 boost 설정시 적용이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     existsQuery(
@@ -63,16 +62,16 @@ class ExistsQueryTest: FunSpec ({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isExists }.find { it.exists().field() == "a" }?.exists()?.field() shouldBe "a"
         mustQuery.filter { it.isExists }.find { it.exists().field() == "a" }?.exists()?.boost() shouldBe 2.0F
     }
 
     test("exists 쿼리에 _name이 설정되면 terms.queryName에 반영되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     existsQuery(
@@ -82,9 +81,9 @@ class ExistsQueryTest: FunSpec ({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isExists }.find { it.exists().field() == "a" }?.exists()?.field() shouldBe "a"
         mustQuery.filter { it.isExists }.find { it.exists().field() == "a" }?.exists()?.queryName() shouldBe "named"

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/RangeQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/RangeQueryTest.kt
@@ -6,13 +6,12 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.ran
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.assertions.print.print
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
-class RangeQueryTest: FunSpec ({
+class RangeQueryTest : FunSpec({
 
     test("must 쿼리에서 range 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -38,9 +37,9 @@ class RangeQueryTest: FunSpec ({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 4
 
         mustQuery.filter { it.isRange && it.range().field() == "a"}.size shouldBe 2
@@ -57,7 +56,7 @@ class RangeQueryTest: FunSpec ({
     }
 
     test("must 쿼리에서 rangeQuery에 boost 설정시 적용이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     rangeQuery(
@@ -69,15 +68,15 @@ class RangeQueryTest: FunSpec ({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isRange }.find { it.range().field() == "d" }?.range()?.boost() shouldBe 3.0F
     }
 
     test("range 쿼리에 _name이 설정되면 range.queryName에 반영되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     rangeQuery(
@@ -89,9 +88,9 @@ class RangeQueryTest: FunSpec ({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isRange }.find { it.range().field() == "d" }!!.range().queryName() shouldBe "named"
     }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermQueryTest.kt
@@ -10,10 +10,10 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
-class TermQueryTest: FunSpec({
+class TermQueryTest : FunSpec({
 
     test("must 쿼리에서 term 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -29,16 +29,16 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 2
         mustQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         mustQuery.filter { it.isTerm }.find { it.term().field() == "b" }?.term()?.value()?.stringValue() shouldBe "2222"
     }
 
     test("must 쿼리에서 termQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -58,9 +58,9 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isTerm }.find { it.term().field() == "a" } shouldBe null
         mustQuery.filter { it.isTerm }.find { it.term().field() == "b" } shouldBe null
@@ -68,7 +68,7 @@ class TermQueryTest: FunSpec({
     }
 
     test("must 쿼리에서 termQuery 송성값이 없어 생성이 안되어 하위 쿼리가 없을때 must쿼리는 생성 안되야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -84,14 +84,14 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 0
     }
 
     test("filter 쿼리에서 term 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     queries[
@@ -107,16 +107,16 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val filterQuery = q.bool().filter()
+        val filterQuery = query.bool().filter()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         filterQuery.size shouldBe 2
         filterQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         filterQuery.filter { it.isTerm }.find { it.term().field() == "b" }?.term()?.value()?.stringValue() shouldBe "2222"
     }
 
     test("filter 쿼리에서 termQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     queries[
@@ -136,9 +136,9 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val filterQuery = q.bool().filter()
+        val filterQuery = query.bool().filter()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         filterQuery.size shouldBe 1
         filterQuery.filter { it.isTerm }.find { it.term().field() == "a" } shouldBe null
         filterQuery.filter { it.isTerm }.find { it.term().field() == "b" } shouldBe null
@@ -146,7 +146,7 @@ class TermQueryTest: FunSpec({
     }
 
     test("filter 쿼리에서 termQuery가 없을때 must쿼리는 생성 안되야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     queries[
@@ -162,14 +162,14 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val filterQuery = q.bool().filter()
+        val filterQuery = query.bool().filter()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         filterQuery.size shouldBe 0
     }
 
     test("mustNot 쿼리에서 term 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustNotQuery {
                     queries[
@@ -185,16 +185,16 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val mustNotQuery = q.bool().mustNot()
+        val mustNotQuery = query.bool().mustNot()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustNotQuery.size shouldBe 2
         mustNotQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         mustNotQuery.filter { it.isTerm }.find { it.term().field() == "b" }?.term()?.value()?.stringValue() shouldBe "2222"
     }
 
     test("mustNot 쿼리에서 termQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustNotQuery {
                     queries[
@@ -214,9 +214,9 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val mustNotQuery = q.bool().mustNot()
+        val mustNotQuery = query.bool().mustNot()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustNotQuery.size shouldBe 1
         mustNotQuery.filter { it.isTerm }.find { it.term().field() == "a" } shouldBe null
         mustNotQuery.filter { it.isTerm }.find { it.term().field() == "b" } shouldBe null
@@ -224,7 +224,7 @@ class TermQueryTest: FunSpec({
     }
 
     test("mustNot 쿼리에서 termQuery가 없을때 must쿼리는 생성 안되야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustNotQuery {
                     queries[
@@ -240,14 +240,14 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val mustNotQuery = q.bool().mustNot()
-
-        q.isBool shouldBe true
+        val mustNotQuery = query.bool().mustNot()
+        
+        query.isBool shouldBe true
         mustNotQuery.size shouldBe 0
     }
 
     test("should 쿼리에서 term 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 shouldQuery {
                     queries[
@@ -263,16 +263,16 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val shouldQuery = q.bool().should()
+        val shouldQuery = query.bool().should()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         shouldQuery.size shouldBe 2
         shouldQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         shouldQuery.filter { it.isTerm }.find { it.term().field() == "b" }?.term()?.value()?.stringValue() shouldBe "2222"
     }
 
     test("should 쿼리에서 termQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 shouldQuery {
                     queries[
@@ -292,9 +292,9 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val shouldQuery = q.bool().should()
+        val shouldQuery = query.bool().should()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         shouldQuery.size shouldBe 1
         shouldQuery.filter { it.isTerm }.find { it.term().field() == "a" } shouldBe null
         shouldQuery.filter { it.isTerm }.find { it.term().field() == "b" } shouldBe null
@@ -302,7 +302,7 @@ class TermQueryTest: FunSpec({
     }
 
     test("should 쿼리에서 termQuery가 없을때 must쿼리는 생성 안되야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 shouldQuery {
                     queries[
@@ -318,14 +318,14 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val shouldQuery = q.bool().should()
+        val shouldQuery = query.bool().should()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         shouldQuery.size shouldBe 0
     }
 
     test("term 쿼리에 boost 설정시 적용이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     termQuery(
@@ -336,16 +336,16 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.value()?.stringValue() shouldBe "1111"
         mustQuery.filter { it.isTerm }.find { it.term().field() == "a" }?.term()?.boost() shouldBe 2.0F
     }
 
     test("term 쿼리에 _name이 설정되면 term.queryName에 반영되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     termQuery(
@@ -356,9 +356,9 @@ class TermQueryTest: FunSpec({
                 }
             }
         }
-        val mustList = q.bool().must()
+        val mustList = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustList.size shouldBe 1
 
         val term = mustList.first().term()

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermsQueryTest.kt
@@ -11,10 +11,10 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
-class TermsQueryTest: FunSpec({
+class TermsQueryTest : FunSpec({
 
     test("must 쿼리에서 terms 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -30,16 +30,16 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 2
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("must 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -63,9 +63,9 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 2
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
@@ -74,7 +74,7 @@ class TermsQueryTest: FunSpec({
     }
 
     test("must 쿼리에서 termsQuery가 없을때 must쿼리는 생성 안되야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     queries[
@@ -91,14 +91,14 @@ class TermsQueryTest: FunSpec({
             }
         }
 
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 0
     }
 
     test("filter 쿼리에서 terms 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery{
                     queries[
@@ -114,16 +114,16 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val filterQuery = q.bool().filter()
+        val filterQuery = query.bool().filter()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         filterQuery.size shouldBe 2
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("filter 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     queries[
@@ -147,9 +147,9 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val filterQuery = q.bool().filter()
+        val filterQuery = query.bool().filter()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         filterQuery.size shouldBe 2
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         filterQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
@@ -158,7 +158,7 @@ class TermsQueryTest: FunSpec({
     }
 
     test("filter 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     queries[
@@ -175,14 +175,14 @@ class TermsQueryTest: FunSpec({
             }
         }
 
-        val filterQuery = q.bool().filter()
+        val filterQuery = query.bool().filter()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         filterQuery.size shouldBe 0
     }
 
     test("mustNot 쿼리에서 terms 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustNotQuery {
                     queries[
@@ -198,16 +198,16 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val mustNotQuery = q.bool().mustNot()
+        val mustNotQuery = query.bool().mustNot()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustNotQuery.size shouldBe 2
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("mustNot 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustNotQuery {
                     queries[
@@ -231,9 +231,9 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val mustNotQuery = q.bool().mustNot()
+        val mustNotQuery = query.bool().mustNot()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustNotQuery.size shouldBe 2
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         mustNotQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
@@ -242,7 +242,7 @@ class TermsQueryTest: FunSpec({
     }
 
     test("mustNot 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 filterQuery {
                     queries[
@@ -258,14 +258,14 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val mustNotQuery = q.bool().mustNot()
+        val mustNotQuery = query.bool().mustNot()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustNotQuery.size shouldBe 0
     }
 
     test("should 쿼리에서 terms 쿼리 생성이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 shouldQuery {
                     queries[
@@ -281,16 +281,16 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val shouldQuery = q.bool().should()
+        val shouldQuery = query.bool().should()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         shouldQuery.size shouldBe 2
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "b" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("3333", "4444")
     }
 
     test("should 쿼리에서 termsQuery에 value 값이 비었거나 null면 제외가 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 shouldQuery {
                     queries[
@@ -314,9 +314,9 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val shouldQuery = q.bool().should()
+        val shouldQuery = query.bool().should()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         shouldQuery.size shouldBe 2
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "a" } shouldBe null
         shouldQuery.filter { it.isTerms }.find { it.terms().field() == "b" } shouldBe null
@@ -325,7 +325,7 @@ class TermsQueryTest: FunSpec({
     }
 
     test("should 쿼리에서 termsQuery가 없을때 filter쿼리는 생성 안되야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 shouldQuery {
                     queries[
@@ -341,14 +341,14 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val shouldQuery = q.bool().should()
+        val shouldQuery = query.bool().should()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         shouldQuery.size shouldBe 0
     }
 
     test("terms 쿼리에 boost 설정시 적용이 되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     termsQuery(
@@ -359,16 +359,16 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().boost() shouldBe 2.5F
     }
 
     test("terms 쿼리에 _name이 설정되면 terms.queryName에 반영되어야함") {
-        val q = query {
+        val query = query {
             boolQuery {
                 mustQuery {
                     termsQuery(
@@ -379,9 +379,9 @@ class TermsQueryTest: FunSpec({
                 }
             }
         }
-        val mustQuery = q.bool().must()
+        val mustQuery = query.bool().must()
 
-        q.isBool shouldBe true
+        query.isBool shouldBe true
         mustQuery.size shouldBe 1
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().terms().value().map { it._get() } shouldContainExactlyInAnyOrder  listOf("1111", "2222")
         mustQuery.filter { it.isTerms }.find { it.terms().field() == "a" }!!.terms().queryName() shouldBe "named"


### PR DESCRIPTION
- Removed SubQueryBuildersTest.kt as its functionality is now covered in NestedBoolQueryTest.kt.
- Updated MatchBoolPrefixQueryTest.kt, MatchPhrasePrefixQueryTest.kt, MatchPhraseQueryTest.kt, MatchQueryTest.kt, ExistsQueryTest.kt, RangeQueryTest.kt, TermQueryTest.kt, TermsQueryTest.kt to use consistent variable naming for query instances.
- Enhanced test cases for nested bool queries to ensure proper structure and validation of generated queries.
- Improved readability and maintainability of test code by standardizing query creation patterns.