### PR TITLE
48 span field masking query 추가 개발

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,4 @@ bin/
 /CLAUDE.md
 /AGENTS.ko.md
 .claude/
-.codex/analyze-requirements.md
-.codex/implement-kotlin-query-dsl.md
-.gemini/analyze-requirements.toml
-.gemini/implement-kotlin-query-dsl.toml
-.requirements/span-containing-query.md
+

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanQueries.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanQueries.kt
@@ -200,6 +200,16 @@ fun Query.Builder.spanFieldMaskingQuery(fn: SpanFieldMaskingQueryDsl.() -> Unit)
 }
 
 /**
+ * Array-style DSL을 위한 clauses 헬퍼 클래스
+ */
+class ClausesArrayHelper(private val clauseBuilders: MutableList<Query?>) {
+    operator fun get(vararg queries: Query?): Unit {
+        clauseBuilders.clear()
+        queries.filterNotNull().forEach { clauseBuilders.add(it) }
+    }
+}
+
+/**
  * Span Near Query DSL 클래스
  * query { spanNearQuery { ... } } 형태로 사용 가능
  */
@@ -210,13 +220,8 @@ class SpanNearQueryDsl {
     var boost: Float? = null
     var _name: String? = null
     
-    // 기존 방식 - clauses 리스트 직접 설정
-    var clauses: List<Query?>?
-        get() = if (clauseBuilders.isEmpty()) null else clauseBuilders.toList()
-        set(value) {
-            clauseBuilders.clear()
-            value?.let { clauseBuilders.addAll(it) }
-        }
+    // Array-style DSL - clauses[query1, query2, ...] 형태로 사용 가능
+    val clauses = ClausesArrayHelper(clauseBuilders)
     
     // DSL 방식 - clause 블록으로 쿼리 추가
     fun clause(query: Query?) {

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanQueries.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanQueries.kt
@@ -5,6 +5,9 @@ import co.elastic.clients.elasticsearch._types.query_dsl.SpanContainingQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.SpanNearQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.SpanQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.SpanTermQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.SpanFieldMaskingQuery
+import co.elastic.clients.util.ObjectBuilder
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * Converts a generic Query object to a specific SpanQuery object, if it is a span query variant.
@@ -21,7 +24,8 @@ private fun Query.toSpanQuery(): SpanQuery? {
         Query.Kind.SpanOr -> SpanQuery.of { s -> s.spanOr(this.spanOr()) }
         Query.Kind.SpanWithin -> SpanQuery.of { s -> s.spanWithin(this.spanWithin()) }
         Query.Kind.SpanMulti -> SpanQuery.of { s -> s.spanMulti(this.spanMulti()) }
-        // Note: span_field_masking is not a direct query kind, it's a parameter within other span queries.
+        // Support span_field_masking as a span query variant if available.
+        Query.Kind.SpanFieldMasking -> SpanQuery.of { s -> s.spanFieldMasking(this.spanFieldMasking()) }
         else -> null
     }
 }
@@ -72,6 +76,28 @@ fun spanNearQuery(
 }
 
 /**
+ * Build a span_field_masking as Query
+ */
+fun spanFieldMaskingQuery(
+    query: Query?,
+    field: String?,
+    boost: Float? = null,
+    _name: String? = null
+): Query? {
+    val span = query?.toSpanQuery() ?: return null
+    val targetField = field?.takeIf { it.isNotBlank() } ?: return null
+
+    val builder = SpanFieldMaskingQuery.Builder()
+        .query(span)
+        .field(targetField)
+
+    boost?.let { builder.boost(it) }
+    _name?.let { builder.queryName(it) }
+
+    return builder.build()._toQuery()
+}
+
+/**
  * Build a span_containing top-level Query from two Query inputs.
  * The inputs must be variants of span queries.
  * Returns null when either input is null or not a valid span query.
@@ -97,3 +123,134 @@ fun spanContainingQuery(
     return builder.build()._toQuery()
 }
 
+/**
+ * Span Field Masking Query DSL 클래스
+ * query { spanFieldMaskingQuery { ... } } 형태로 사용 가능
+ */
+class SpanFieldMaskingQueryDsl {
+    internal val queryBuilders = SubQueryBuilders()
+    var field: String? = null
+    var boost: Float? = null
+    var _name: String? = null
+
+    /**
+     * 마스킹할 스팬 쿼리 설정
+     */
+    fun query(fn: SubQueryBuilders.() -> Any?) {
+        val sub = SubQueryBuilders()
+        val result = sub.fn()
+        if (sub.size() == 0 && result is Query) {
+            sub.addQuery(result)
+        }
+        queryBuilders.addAll(sub)
+    }
+
+    internal fun buildQuery(): Query? {
+        val spanQuery = when (queryBuilders.size()) {
+            0 -> return null
+            1 -> {
+                var result: Query? = null
+                queryBuilders.forEach { result = it }
+                result
+            }
+            else -> return null // span_field_masking은 단일 쿼리만 지원
+        }
+
+        return spanFieldMaskingQuery(
+            query = spanQuery,
+            field = field,
+            boost = boost,
+            _name = _name
+        )
+    }
+}
+
+/**
+ * Query.Builder를 위한 spanFieldMaskingQuery DSL 확장 함수
+ * query { spanFieldMaskingQuery { ... } } 형태로 사용 가능
+ */
+fun Query.Builder.spanFieldMaskingQuery(fn: SpanFieldMaskingQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = SpanFieldMaskingQueryDsl().apply(fn)
+    
+    // 입력된 쿼리와 필드 유효성 확인
+    val query = when (dsl.queryBuilders.size()) {
+        0 -> return this // 쿼리가 없으면 no-op
+        1 -> {
+            var result: Query? = null
+            dsl.queryBuilders.forEach { result = it }
+            result
+        }
+        else -> return this // 여러 쿼리는 지원하지 않음
+    }
+    
+    val spanQuery = query?.toSpanQuery()
+    val field = dsl.field?.takeIf { it.isNotBlank() }
+    
+    return if (spanQuery != null && field != null) {
+        this.spanFieldMasking { sfm ->
+            sfm.query(spanQuery)
+            sfm.field(field)
+            dsl.boost?.let { sfm.boost(it) }
+            dsl._name?.let { sfm.queryName(it) }
+            sfm
+        }
+    } else {
+        this // no-op if invalid inputs
+    }
+}
+
+/**
+ * Span Near Query DSL 클래스
+ * query { spanNearQuery { ... } } 형태로 사용 가능
+ */
+class SpanNearQueryDsl {
+    private val clauseBuilders = mutableListOf<Query?>()
+    var slop: Int? = null
+    var inOrder: Boolean? = null
+    var boost: Float? = null
+    var _name: String? = null
+    
+    // 기존 방식 - clauses 리스트 직접 설정
+    var clauses: List<Query?>?
+        get() = if (clauseBuilders.isEmpty()) null else clauseBuilders.toList()
+        set(value) {
+            clauseBuilders.clear()
+            value?.let { clauseBuilders.addAll(it) }
+        }
+    
+    // DSL 방식 - clause 블록으로 쿼리 추가
+    fun clause(query: Query?) {
+        query?.let { clauseBuilders.add(it) }
+    }
+    
+    internal fun getClauses(): List<Query?> = clauseBuilders.toList()
+}
+
+/**
+ * Query.Builder를 위한 spanNearQuery DSL 확장 함수
+ * query { spanNearQuery { ... } } 형태로 사용 가능
+ */
+fun Query.Builder.spanNearQuery(fn: SpanNearQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = SpanNearQueryDsl().apply(fn)
+    
+    val clauses = dsl.getClauses()
+    val slop = dsl.slop
+    
+    if (clauses.isEmpty() || slop == null || slop < 0) {
+        return this // no-op if invalid inputs
+    }
+    
+    val validSpanClauses = clauses.mapNotNull { it?.toSpanQuery() }
+    if (validSpanClauses.isEmpty()) {
+        return this // no-op if no valid span clauses
+    }
+    
+    return this.spanNear { snq ->
+        snq.clauses(validSpanClauses)
+        snq.slop(slop)
+        dsl.inOrder?.let { snq.inOrder(it) }
+        dsl.boost?.let { snq.boost(it) }
+        dsl._name?.let { snq.queryName(it) }
+        snq
+    }
+}

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFieldMaskingQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFieldMaskingQueryTest.kt
@@ -77,14 +77,14 @@ class SpanFieldMaskingQueryTest : FunSpec({
         val near =
             query {
                 spanNearQuery {
-                    // DSL 방식으로 clause 추가
-                    clause(spanTermQuery("text", "quick"))
-                    clause(
+                    // Array-style DSL - clauses[query1, query2, ...] 형태로 사용
+                    clauses[
+                        spanTermQuery("text", "quick"),
                         spanFieldMaskingQuery(
                             query = spanTermQuery("text.stems", "fox"),
                             field = "text"
                         )
-                    )
+                    ]
                     slop = 5
                     inOrder = false
                 }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFieldMaskingQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFieldMaskingQueryTest.kt
@@ -1,0 +1,171 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.matchAllQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class SpanFieldMaskingQueryTest : FunSpec({
+
+    test("span_field_masking: 기본 동작 및 속성 확인") {
+        val q =
+            query {
+                spanFieldMaskingQuery {
+                    query {
+                        spanTermQuery("text.stems", "fox")
+                    }
+                    field = "text"
+                    boost = 2.0f
+                    _name = "mask-fox"
+                }
+            }
+
+        q shouldNotBe null
+        // top-level kind check
+        q.isSpanFieldMasking shouldBe true
+
+        val sfm = q.spanFieldMasking()
+        sfm.field() shouldBe "text"
+        sfm.boost() shouldBe 2.0f
+        sfm.queryName() shouldBe "mask-fox"
+
+        // inner span query retained
+        sfm.query().isSpanTerm shouldBe true
+    }
+
+    test("span_field_masking: null/blank 입력 시 생략") {
+        // null value로 인해 spanTermQuery가 null을 반환하므로 spanFieldMaskingQuery도 no-op
+        val nullInnerResult =
+            query {
+                spanFieldMaskingQuery {
+                    query {
+                        spanTermQuery("text.stems", null)
+                    }
+                    field = "text"
+                }
+                matchAll { it } // fallback
+            }
+        nullInnerResult.isMatchAll shouldBe true // spanFieldMaskingQuery가 no-op이므로 matchAll만 남음
+
+        // blank field로 인해 spanFieldMaskingQuery가 no-op
+        val blankFieldResult =
+            query {
+                spanFieldMaskingQuery {
+                    query {
+                        spanTermQuery("text.stems", "fox")
+                    }
+                    field = " " // blank field
+                }
+                matchAll { it } // fallback
+            }
+        blankFieldResult.isMatchAll shouldBe true // spanFieldMaskingQuery가 no-op이므로 matchAll만 남음
+
+        // 빈 query 블록으로 인해 spanFieldMaskingQuery가 no-op
+        val emptyQueryResult =
+            query {
+                spanFieldMaskingQuery {
+                    // query 블록을 설정하지 않음
+                    field = "text"
+                }
+                matchAll { it } // fallback
+            }
+        emptyQueryResult.isMatchAll shouldBe true // spanFieldMaskingQuery가 no-op이므로 matchAll만 남음
+    }
+
+    test("span_field_masking: span_near 내에서 동작") {
+        val near =
+            query {
+                spanNearQuery {
+                    // DSL 방식으로 clause 추가
+                    clause(spanTermQuery("text", "quick"))
+                    clause(
+                        spanFieldMaskingQuery(
+                            query = spanTermQuery("text.stems", "fox"),
+                            field = "text"
+                        )
+                    )
+                    slop = 5
+                    inOrder = false
+                }
+            }
+
+        near shouldNotBe null
+        near.isSpanNear shouldBe true
+
+        val built = near.spanNear()
+        built.clauses().size shouldBe 2
+        built.clauses()[0].isSpanTerm shouldBe true
+        built.clauses()[1].isSpanFieldMasking shouldBe true
+
+        val sfm = built.clauses()[1].spanFieldMasking()
+        sfm.field() shouldBe "text"
+        sfm.query().isSpanTerm shouldBe true
+    }
+
+    test("query { spanFieldMaskingQuery { ... } }: DSL 형태로 사용") {
+        val q = query {
+            spanFieldMaskingQuery {
+                query { spanTermQuery("text.stems", "fox") }
+                field = "text"
+                boost = 2.0f
+                _name = "mask-query"
+            }
+        }
+
+        q shouldNotBe null
+        q.isSpanFieldMasking shouldBe true
+
+        val sfm = q.spanFieldMasking()
+        sfm.field() shouldBe "text"
+        sfm.boost() shouldBe 2.0f
+        sfm.queryName() shouldBe "mask-query"
+        sfm.query().isSpanTerm shouldBe true
+    }
+
+    test("query { spanFieldMaskingQuery { ... } }: 빈 쿼리 처리") {
+        // DSL에서 빈 쿼리 시 no-op 되는지 확인
+        val q = query {
+            spanFieldMaskingQuery {
+                // query를 설정하지 않음 (빈 쿼리)
+                field = "text"
+            }
+            matchAll { it } // fallback으로 추가
+        }
+
+        // spanFieldMaskingQuery가 no-op이므로 match_all만 남음
+        q.isMatchAll shouldBe true
+
+        // DSL에서 null field 시 no-op 되는지 확인
+        val q2 = query {
+            spanFieldMaskingQuery {
+                query { spanTermQuery("text.stems", "fox") }
+                field = null // null field
+            }
+            matchAll { it } // fallback으로 추가
+        }
+
+        // spanFieldMaskingQuery가 no-op이므로 match_all만 남음
+        q2.isMatchAll shouldBe true
+    }
+
+    test("SubQueryBuilders와의 통합: query 함수 내에서 사용") {
+        val spanMaskingQuery =
+            query {
+                spanFieldMaskingQuery {
+                    query {
+                        spanTermQuery("text.stems", "fox")
+                    }
+                    field = "text"
+                }
+            }
+        
+        spanMaskingQuery shouldNotBe null
+        spanMaskingQuery.isSpanFieldMasking shouldBe true
+        
+        val sfm = spanMaskingQuery.spanFieldMasking()
+        sfm.field() shouldBe "text"
+        sfm.query().isSpanTerm shouldBe true
+    }
+})
+

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/MatchAllQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/MatchAllQueryTest.kt
@@ -1,10 +1,8 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel
 
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.matchAllQuery
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermQueryTest.kt
@@ -29,6 +29,7 @@ class TermQueryTest : FunSpec({
                 }
             }
         }
+
         val mustQuery = query.bool().must()
 
         query.isBool shouldBe true


### PR DESCRIPTION
This pull request introduces comprehensive support for Elasticsearch span queries, particularly focusing on the addition of the `span_field_masking` and enhanced `span_near` query DSLs. The changes provide both function-style and DSL-style APIs, improve type safety, and ensure invalid queries are excluded dynamically. Extensive documentation and tests have been added to demonstrate usage and verify correctness.

**Span Query DSL Enhancements:**

* Added `spanFieldMaskingQuery` function and DSL, allowing users to compose span field masking queries with validation for required fields and inner queries. Returns `null` for invalid inputs, ensuring only valid queries are included in the final DSL output. [[1]](diffhunk://#diff-b8ff1cc2895f0c36c255a884d3d49902dcb57dd49741cc54ec51a1ece9d540e5R78-R99) [[2]](diffhunk://#diff-b8ff1cc2895f0c36c255a884d3d49902dcb57dd49741cc54ec51a1ece9d540e5R126-R261)
* Enhanced `spanNearQuery` DSL to support both array-style (`clauses[...]`) and incremental (`clause(...)`) clause addition, with automatic filtering of non-span queries for type safety.
* Updated internal conversion logic to treat `span_field_masking` as a valid span query variant for seamless integration.

**Documentation Updates:**

* Expanded `README.md` to include detailed usage examples, options tables, and integration notes for both `span_field_masking` and `span_near` queries, illustrating function-style and DSL-style usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R175-R288) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R372-R399)

**Testing:**

* Added `SpanFieldMaskingQueryTest.kt` to verify correct behavior, dynamic exclusion of invalid queries, and integration with other span queries.

These changes significantly improve the flexibility and safety of span query composition in the library, making advanced Elasticsearch text queries easier to write and maintain.