### PR TITLE
feat: SpanFirstQuery 및 SpanMultiQuery 추가 및 테스트 케이스 작성

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -396,3 +396,7 @@ Simple query string
 - 배열 스타일: `clauses[spanTermQuery("field", "value"), ...]`
 - 개별 추가: `clause(spanTermQuery("field", "value"))`
 - 두 패턴 모두 비-스팬 쿼리는 자동 필터링
+
+## 기여하기
+
+기여를 환영합니다. 프로젝트 구조, 코딩 스타일, 테스트, PR 규칙은 [AGENTS.md](AGENTS.md)를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -397,3 +397,7 @@ Span Near Query (span_near)
 - Array-style: `clauses[spanTermQuery("field", "value"), ...]`
 - Individual: `clause(spanTermQuery("field", "value"))`
 - Both patterns automatically filter non-span queries
+
+## Contributing
+
+Contributions are welcome. Please read the contributor guide in [AGENTS.md](AGENTS.md) for project structure, coding style, testing, and PR conventions.

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFirstQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFirstQuery.kt
@@ -1,0 +1,45 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.SpanQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.SpanFirstQuery as EsSpanFirstQuery
+
+class SpanFirstQueryBuilder {
+    var match: Query? = null
+    var end: Int? = null
+    var boost: Float? = null
+    var _name: String? = null
+
+    internal fun build(): Query? {
+        val nonNullMatch = match ?: return null
+        val nonNullEnd = end ?: throw IllegalArgumentException("The 'end' parameter is required for a span_first query.")
+
+        val spanQueryVariant: SpanQuery = when (nonNullMatch._kind()) {
+            Query.Kind.SpanTerm -> SpanQuery.Builder().spanTerm(nonNullMatch.spanTerm()).build()
+            Query.Kind.SpanNear -> SpanQuery.Builder().spanNear(nonNullMatch.spanNear()).build()
+            Query.Kind.SpanOr -> SpanQuery.Builder().spanOr(nonNullMatch.spanOr()).build()
+            Query.Kind.SpanContaining -> SpanQuery.Builder().spanContaining(nonNullMatch.spanContaining()).build()
+            Query.Kind.SpanWithin -> SpanQuery.Builder().spanWithin(nonNullMatch.spanWithin()).build()
+            Query.Kind.SpanNot -> SpanQuery.Builder().spanNot(nonNullMatch.spanNot()).build()
+            Query.Kind.SpanMulti -> SpanQuery.Builder().spanMulti(nonNullMatch.spanMulti()).build()
+            Query.Kind.SpanFirst -> SpanQuery.Builder().spanFirst(nonNullMatch.spanFirst()).build()
+            Query.Kind.SpanFieldMasking -> SpanQuery.Builder().spanFieldMasking(nonNullMatch.spanFieldMasking()).build()
+            else -> throw IllegalArgumentException("The provided 'match' query of kind '${nonNullMatch._kind()}' is not a valid span query type.")
+        }
+
+        return Query.of { q -> 
+            q.spanFirst(
+                EsSpanFirstQuery.Builder()
+                    .match(spanQueryVariant)
+                    .end(nonNullEnd)
+                    .boost(boost)
+                    .queryName(_name)
+                    .build()
+            )
+        }
+    }
+}
+
+fun spanFirstQuery(block: SpanFirstQueryBuilder.() -> Unit): Query? {
+    return SpanFirstQueryBuilder().apply(block).build()
+}

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFirstQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFirstQueryTest.kt
@@ -1,0 +1,59 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class SpanFirstQueryTest : FunSpec({
+    test("spanFirstQuery with lambda should build a valid query") {
+        val query = query {
+            boolQuery {
+                mustQuery {
+                    spanFirstQuery {
+                        match = spanTermQuery("user.id", "kimchy")
+                        end = 3
+                        boost = 1.2f
+                        _name = "my_query"
+                    }
+                }
+            }
+        }
+
+        val expected = """Query: {"bool":{"must":[{"span_first":{"boost":1.2000000476837158,"_name":"my_query","end":3,"match":{"span_term":{"user.id":{"value":"kimchy"}}}}}]}}"""
+
+        query.shouldNotBeNull()
+        query.toString() shouldBe expected
+    }
+
+    test("spanFirstQuery should return null if match is not set") {
+        val query = spanFirstQuery {
+            end = 3
+        }
+        query shouldBe null
+    }
+
+    test("spanFirstQuery should throw exception if end is not set") {
+        shouldThrow<IllegalArgumentException> {
+            spanFirstQuery {
+                match = spanTermQuery("user.id", "kimchy")
+            }
+        }
+    }
+
+    test("Simple spanFirstQuery usage") {
+        val dsl = spanFirstQuery {
+            match = spanTermQuery(field = "user.id", value = "kimchy")
+            end = 3
+        }
+
+        val expected = """Query: {"span_first":{"end":3,"match":{"span_term":{"user.id":{"value":"kimchy"}}}}}"""
+
+        dsl.shouldNotBeNull()
+        dsl.toString() shouldBe expected
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanMultiQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanMultiQueryTest.kt
@@ -1,0 +1,99 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.rangeQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class SpanMultiQueryTest : FunSpec({
+
+    test("span_multi: range 쿼리를 match로 래핑") {
+        val match = rangeQuery(
+            field = "publish_date",
+            gte = "2023-01-01"
+        )
+
+        val q = spanMultiQuery(
+            match = match,
+            boost = 1.1f,
+            _name = "range-as-span"
+        )
+
+        q shouldNotBe null
+        q!!.isSpanMulti shouldBe true
+
+        val sm = q.spanMulti()
+        sm.boost() shouldBe 1.1f
+        sm.queryName() shouldBe "range-as-span"
+        sm.match().isRange shouldBe true
+        sm.match().range().field() shouldBe "publish_date"
+        sm.match().range().gte()?.to(String::class.java) shouldBe "2023-01-01"
+    }
+
+    test("span_multi: span_near 내부 clause로 사용") {
+        val near = query {
+            spanNearQuery {
+                clauses[
+                    spanTermQuery("title", "elasticsearch"),
+                    spanMultiQuery(
+                        match = rangeQuery("publish_date", gte = "2023-01-01")
+                    )
+                ]
+                slop = 3
+                inOrder = true
+            }
+        }
+
+        near.isSpanNear shouldBe true
+        val built = near.spanNear()
+        built.clauses().size shouldBe 2
+        built.clauses()[0].isSpanTerm shouldBe true
+        built.clauses()[1].isSpanMulti shouldBe true
+        built.clauses()[1].spanMulti().match().isRange shouldBe true
+    }
+
+    test("query { spanMultiQuery { ... } }: DSL 형태와 생략 규칙") {
+        // 정상 DSL
+        val q = query {
+            spanMultiQuery {
+                match { rangeQuery("publish_date", gte = "2023-01-01") }
+                boost = 2.0f
+                _name = "dsl-range-span"
+            }
+        }
+
+        q.isSpanMulti shouldBe true
+        q.spanMulti().boost() shouldBe 2.0f
+        q.spanMulti().queryName() shouldBe "dsl-range-span"
+        q.spanMulti().match().isRange shouldBe true
+
+        // match 미제공 → no-op (fallback 사용)
+        val q2 = query {
+            spanMultiQuery {
+                // no match
+                boost = 1.0f
+            }
+            matchAll { it } // fallback
+        }
+        q2.isMatchAll shouldBe true
+
+        // 멀티텀이 아닌 match 사용 → no-op (fallback 사용)
+        val q3 = query {
+            spanMultiQuery {
+                match { spanTermQuery("title", "x") }
+            }
+            matchAll { it } // fallback
+        }
+        q3.isMatchAll shouldBe true
+    }
+
+    test("spanMultiQuery(match = null) 또는 비-멀티텀은 null 반환") {
+        val nullMatch = spanMultiQuery(match = null)
+        nullMatch shouldBe null
+
+        val nonMulti = spanMultiQuery(match = spanTermQuery("f", "v"))
+        nonMulti shouldBe null
+    }
+})
+


### PR DESCRIPTION
This pull request introduces new support for the `span_first` and `span_multi` query types in the dynamic Elasticsearch query DSL, including both builder functions and DSL-style usage. It also adds comprehensive tests for these new features and updates documentation to help contributors.

**New Query Builders and DSL Support:**

* Added `SpanFirstQueryBuilder` and the `spanFirstQuery` function to support building `span_first` queries in a type-safe and idiomatic way. Includes validation for required parameters.
* Added `spanMultiQuery` builder function and `SpanMultiQueryDsl` class for constructing `span_multi` queries, supporting both direct and DSL-style usage, with validation for allowed multi-term query types. [[1]](diffhunk://#diff-b8ff1cc2895f0c36c255a884d3d49902dcb57dd49741cc54ec51a1ece9d540e5R101-R129) [[2]](diffhunk://#diff-b8ff1cc2895f0c36c255a884d3d49902dcb57dd49741cc54ec51a1ece9d540e5R232-R308)
* Updated imports to include `SpanMultiQuery` for the new functionality.

**Testing:**

* Added `SpanFirstQueryTest` and `SpanMultiQueryTest` to ensure correct behavior, parameter validation, and integration of the new query types within compound queries and DSL usage. [[1]](diffhunk://#diff-47d795abbcf61bfa7740c0f301d5d3aebafe0ea7cf6b44cbf8d08b4724418aa7R1-R59) [[2]](diffhunk://#diff-4feee2de5fdbfe8cbf04ac4b7173fac870b446ea5f6eb3d145aead67fd8468ecR1-R99)

**Documentation:**

* Updated both English and Korean `README` files to include a "Contributing" section with a link to the contributor guide. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R400-R403) [[2]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR399-R402)