### PR TITLE
52 span queries 관련 쿼리 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ bin/
 /AGENTS.ko.md
 .claude/
 
+.requirements/
+.requirements-backup/

--- a/README.md
+++ b/README.md
@@ -286,6 +286,88 @@ See tests:
 - [SpanFieldMaskingQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFieldMaskingQueryTest.kt)
 - [SpanFieldMaskingParityTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFieldMaskingParityTest.kt)
 
+#### Span Or Query
+The `span_or` query matches if any of the provided span clauses match.
+
+```kotlin
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext.*
+
+// Function-style
+val orQuery = spanOrQuery(
+    clauses = listOf(
+        spanTermQuery("title", "kotlin"),
+        spanTermQuery("title", "dsl"),
+        spanNearQuery(
+            clauses = listOf(
+                spanTermQuery("title", "structured"),
+                spanTermQuery("title", "concurrency")
+            ),
+            slop = 1
+        )
+    ),
+    _name = "span_or_example"
+)
+
+// DSL-style
+val orDsl = query {
+    spanOrQuery {
+        clauses[
+            spanTermQuery("title", "kotlin"),
+            spanTermQuery("title", "dsl")
+        ]
+        _name = "span_or_dsl"
+    }
+}
+```
+
+Note: Non-span queries are filtered automatically. If no valid clauses remain, the DSL behaves as a no-op.
+
+See tests: [SpanOrQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanOrQueryTest.kt)
+
+#### Span Within Query
+The `span_within` query matches when the little span is entirely contained within the big span.
+
+```kotlin
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext.*
+
+// Function-style
+val within = spanWithinQuery(
+    little = spanTermQuery("body", "green"),
+    big = spanNearQuery(
+        clauses = listOf(
+            spanTermQuery("body", "green"),
+            spanTermQuery("body", "apple")
+        ),
+        slop = 2,
+        inOrder = true
+    ),
+    _name = "within_green"
+)
+
+// DSL-style
+val withinDsl = query {
+    spanWithinQuery {
+        little { spanTermQuery("body", "green") }
+        big {
+            spanNearQuery(
+                clauses = listOf(
+                    spanTermQuery("body", "green"),
+                    spanTermQuery("body", "apple")
+                ),
+                slop = 1
+            )
+        }
+        _name = "within_dsl"
+    }
+}
+```
+
+Note: Both `little` and `big` must be valid span queries; if either is missing or non-span, the DSL behaves as a no-op.
+
+See tests: [SpanWithinQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanWithinQueryTest.kt)
+
 ## Function Score
 Compose per‑function filters, field value factor, weight, random, and decay.
 
@@ -397,6 +479,36 @@ Span Near Query (span_near)
 - Array-style: `clauses[spanTermQuery("field", "value"), ...]`
 - Individual: `clause(spanTermQuery("field", "value"))`
 - Both patterns automatically filter non-span queries
+
+Span Or Query (span_or)
+
+| Option | Type | Notes |
+|---|---|---|
+| `clauses` | Array/List | Span-only; non-span inputs are filtered |
+| `boost` | Float | Query boost factor |
+| `_name` | String | Query name for debugging |
+
+Span Within Query (span_within)
+
+| Option | Type | Notes |
+|---|---|---|
+| `little` | SpanQuery | Required. The inner (contained) span |
+| `big` | SpanQuery | Required. The outer (containing) span |
+| `boost` | Float | Query boost factor |
+| `_name` | String | Query name for debugging |
+
+Span Not Query (span_not)
+
+| Option | Type | Notes |
+|---|---|---|
+| `include` | SpanQuery | Required. The included span query |
+| `exclude` | SpanQuery | Required. The excluded span query |
+| `pre` | Int | >= 0. Max tokens allowed before include |
+| `post` | Int | >= 0. Max tokens allowed after include |
+| `boost` | Float | Query boost factor |
+| `_name` | String | Query name for debugging |
+
+See tests: [SpanNotQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanNotQueryTest.kt)
 
 ## Contributing
 

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanQueries.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanQueries.kt
@@ -56,6 +56,38 @@ fun spanTermQuery(
 }
 
 /**
+ * Span Term Query DSL 클래스
+ * query { spanTermQuery { ... } } 형태로 사용 가능
+ */
+class SpanTermQueryDsl {
+    var field: String? = null
+    var value: String? = null
+    var boost: Float? = null
+    var _name: String? = null
+}
+
+/**
+ * Query.Builder를 위한 spanTermQuery DSL 확장 함수
+ */
+fun Query.Builder.spanTermQuery(fn: SpanTermQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = SpanTermQueryDsl().apply(fn)
+    val field = dsl.field?.takeIf { it.isNotBlank() }
+    val value = dsl.value?.takeIf { it.isNotBlank() }
+
+    return if (field != null && value != null) {
+        this.spanTerm { st ->
+            st.field(field)
+            st.value(value)
+            dsl.boost?.let { st.boost(it) }
+            dsl._name?.let { st.queryName(it) }
+            st
+        }
+    } else {
+        this // no-op when invalid inputs
+    }
+}
+
+/**
  * Build a span_near as Query
  */
 fun spanNearQuery(

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanQueries.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanQueries.kt
@@ -6,7 +6,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.SpanNearQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.SpanQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.SpanTermQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.SpanFieldMaskingQuery
-import co.elastic.clients.elasticsearch._types.query_dsl.SpanMultiQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.SpanMultiTermQuery
 import co.elastic.clients.util.ObjectBuilder
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
@@ -118,7 +118,7 @@ fun spanMultiQuery(
     }
     if (!isMultiTerm) return null
 
-    val builder = SpanMultiQuery.Builder()
+    val builder = SpanMultiTermQuery.Builder()
         .match(m)
 
     boost?.let { builder.boost(it) }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanContainingDslTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanContainingDslTest.kt
@@ -1,0 +1,32 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SpanContainingDslTest : FunSpec({
+    test("span_containing: 블록 DSL 동작 및 속성 확인") {
+        val q = query {
+            spanContainingQuery {
+                little { spanTermQuery("body", "green") }
+                big {
+                    spanNearQuery(
+                        clauses = listOf(
+                            spanTermQuery("body", "green"),
+                            spanTermQuery("body", "apple")
+                        ),
+                        slop = 1,
+                        inOrder = true
+                    )
+                }
+                _name = "containing_dsl"
+            }
+        }
+
+        q.isSpanContaining shouldBe true
+        q.spanContaining().queryName() shouldBe "containing_dsl"
+        q.spanContaining().little().isSpanTerm shouldBe true
+        q.spanContaining().big().isSpanNear shouldBe true
+    }
+})
+

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFirstDslTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFirstDslTest.kt
@@ -1,0 +1,25 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SpanFirstDslTest : FunSpec({
+    test("span_first: 블록 DSL 동작 및 속성 확인") {
+        val q = query {
+            spanFirstQueryDsl {
+                match { spanTermQuery("user.id", "kimchy") }
+                end = 3
+                boost = 1.2f
+                _name = "first_dsl"
+            }
+        }
+
+        q.isSpanFirst shouldBe true
+        val sf = q.spanFirst()
+        sf.end() shouldBe 3
+        sf.boost() shouldBe 1.2f
+        sf.queryName() shouldBe "first_dsl"
+        sf.match().isSpanTerm shouldBe true
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanNearQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanNearQueryTest.kt
@@ -1,0 +1,98 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class SpanNearQueryTest : FunSpec({
+
+    test("span_near: inOrder 미설정 시 기본 false") {
+        val q = query {
+            spanNearQuery {
+                clause(spanTermQuery("title", "kotlin"))
+                clause(spanTermQuery("title", "dsl"))
+                slop = 2
+                // inOrder 미설정
+            }
+        }
+
+        q.isSpanNear shouldBe true
+        val near = q.spanNear()
+        near.slop() shouldBe 2
+        // in_order 미설정 시 JSON 생략 → getter는 null일 수 있음
+        near.inOrder() shouldBe null
+        near.clauses().size shouldBe 2
+    }
+
+    test("span_near: DSL no-op이면 fallback 유지") {
+        val q = query {
+            spanNearQuery {
+                // 유효하지 않은 slop
+                slop = -1
+            }
+            // no-op 이후 fallback 으로 match_all 유지
+            matchAll { it }
+        }
+
+        q.isMatchAll shouldBe true
+    }
+
+    test("span_near: 혼합 절에서 비-span 제외") {
+        val q = query {
+            spanNearQuery {
+                slop = 1
+                clauses[
+                    spanTermQuery("title", "kotlin"),
+                    // 비-span 쿼리 (matchQuery)는 자동 필터링되어 제외됨
+                    matchQuery("title", "dsl")
+                ]
+            }
+        }
+
+        q.isSpanNear shouldBe true
+        val near = q.spanNear()
+        near.clauses().size shouldBe 1
+        near.clauses()[0].isSpanTerm shouldBe true
+    }
+
+    test("span_near: 단일 절 허용 및 정상 동작") {
+        val q = query {
+            spanNearQuery {
+                slop = 0
+                clause(spanTermQuery("title", "single"))
+            }
+        }
+
+        q.isSpanNear shouldBe true
+        val near = q.spanNear()
+        near.clauses().size shouldBe 1
+        // in_order 미설정 시 JSON 생략 → getter는 null일 수 있음
+        near.inOrder() shouldBe null
+    }
+
+    test("span_near: 중첩 span_near 허용") {
+        val inner = spanNearQuery(
+            clauses = listOf(
+                spanTermQuery("title", "structured"),
+                spanTermQuery("title", "concurrency")
+            ),
+            slop = 2
+        )
+
+        val q = query {
+            spanNearQuery {
+                slop = 5
+                clauses[
+                    spanTermQuery("title", "kotlin"),
+                    inner
+                ]
+            }
+        }
+
+        q.isSpanNear shouldBe true
+        val near = q.spanNear()
+        near.clauses().size shouldBe 2
+        near.clauses()[0].isSpanTerm shouldBe true
+        near.clauses()[1].isSpanNear shouldBe true
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanNotQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanNotQueryTest.kt
@@ -1,0 +1,89 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class SpanNotQueryTest : FunSpec({
+
+    test("span_not: 기본 동작 및 속성 확인") {
+        val include = spanNearQuery(
+            clauses = listOf(
+                spanTermQuery("title", "kotlin"),
+                spanTermQuery("title", "dsl")
+            ),
+            slop = 3,
+            inOrder = true
+        )
+        val exclude = spanTermQuery("title", "legacy")
+
+        val q = spanNotQuery(
+            include = include,
+            exclude = exclude,
+            pre = 0,
+            post = 1,
+            boost = 1.0f,
+            _name = "not_legacy"
+        )
+
+        q shouldNotBe null
+        q!!.isSpanNot shouldBe true
+        val sn = q.spanNot()
+        sn.queryName() shouldBe "not_legacy"
+        sn.boost() shouldBe 1.0f
+        sn.pre() shouldBe 0
+        sn.post() shouldBe 1
+        sn.include().isSpanNear shouldBe true
+        sn.exclude().isSpanTerm shouldBe true
+    }
+
+    test("span_not: DSL no-op이면 fallback 유지") {
+        val q = query {
+            spanNotQuery {
+                // include 미제공 → no-op
+                exclude { spanTermQuery("f", "v") }
+                pre = -1 // 무시
+            }
+            matchAll { it } // fallback 유지
+        }
+
+        q.isMatchAll shouldBe true
+    }
+
+    test("span_not: include 또는 exclude 가 null이면 null 반환") {
+        val ex = spanTermQuery("f", "v")
+        val q1 = spanNotQuery(include = null, exclude = ex)
+        q1 shouldBe null
+
+        val inc = spanTermQuery("f", "v")
+        val q2 = spanNotQuery(include = inc, exclude = null)
+        q2 shouldBe null
+    }
+
+    test("span_not: include/exclude 에 비-span 전달 시 생략") {
+        val nonSpan = matchQuery("title", "text")
+        val ex = spanTermQuery("title", "legacy")
+        val q = spanNotQuery(include = nonSpan, exclude = ex)
+        q shouldBe null
+    }
+
+    test("span_not: 중첩 span_not 허용") {
+        val inner = spanNotQuery(
+            include = spanTermQuery("body", "green"),
+            exclude = spanTermQuery("body", "apple")
+        )
+
+        val outer = spanNotQuery(
+            include = spanTermQuery("body", "fruit"),
+            exclude = inner
+        )
+
+        outer shouldNotBe null
+        outer!!.isSpanNot shouldBe true
+        val sn = outer.spanNot()
+        sn.include().isSpanTerm shouldBe true
+        sn.exclude().isSpanNot shouldBe true
+    }
+})
+

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanOrQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanOrQueryTest.kt
@@ -1,0 +1,67 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class SpanOrQueryTest : FunSpec({
+
+    test("span_or: 기본 동작 및 속성 확인") {
+        val q = spanOrQuery(
+            clauses = listOf(
+                spanTermQuery("title", "kotlin"),
+                spanTermQuery("title", "dsl")
+            ),
+            boost = 1.1f,
+            _name = "span_or_example"
+        )
+
+        q shouldNotBe null
+        q!!.isSpanOr shouldBe true
+        val so = q.spanOr()
+        so.boost() shouldBe 1.1f
+        so.queryName() shouldBe "span_or_example"
+        so.clauses().size shouldBe 2
+        so.clauses()[0].isSpanTerm shouldBe true
+    }
+
+    test("span_or: 비-span 혼합 시 필터링, 모두 비-span이면 null") {
+        val q = spanOrQuery(
+            clauses = listOf(
+                matchQuery("f", "v"),
+                spanTermQuery("f", "v")
+            )
+        )
+        q shouldNotBe null
+        q!!.spanOr().clauses().size shouldBe 1
+        q.spanOr().clauses()[0].isSpanTerm shouldBe true
+
+        val q2 = spanOrQuery(clauses = listOf(matchQuery("f", "v")))
+        q2 shouldBe null
+    }
+
+    test("span_or: 블록 DSL 동작 및 no-op fallback") {
+        val built = query {
+            spanOrQuery {
+                clauses[
+                    spanTermQuery("title", "kotlin"),
+                    matchQuery("title", "dsl") // 비-span은 필터링되어 제외됨
+                ]
+                _name = "span_or_dsl"
+            }
+        }
+        built.isSpanOr shouldBe true
+        built.spanOr().queryName() shouldBe "span_or_dsl"
+        built.spanOr().clauses().size shouldBe 1
+
+        val fallback = query {
+            spanOrQuery {
+                // 유효 clause 없음 → no-op
+                clauses[ matchQuery("f", "v") ]
+            }
+            matchAll { it }
+        }
+        fallback.isMatchAll shouldBe true
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanTermQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanTermQueryTest.kt
@@ -1,0 +1,42 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class SpanTermQueryTest : FunSpec({
+
+    test("span_term: DSL 루트(query { ... }) 기본 동작 및 속성 확인") {
+        val q = query {
+            spanTermQuery {
+                field = "title"
+                value = "kotlin"
+                boost = 1.2f
+                _name = "term_kotlin"
+            }
+        }
+
+        q.isSpanTerm shouldBe true
+        val st = q.spanTerm()
+        st.field() shouldBe "title"
+        // Value extraction API differs across client variants; assert content presence
+        st.value().toString().lowercase().contains("kotlin") shouldBe true
+        st.boost() shouldBe 1.2f
+        st.queryName() shouldBe "term_kotlin"
+    }
+
+    test("span_term: DSL no-op 시 fallback 유지 (invalid helper ignored)") {
+        val built = query {
+            // 블록 DSL에서 유효하지 않은 입력 → no-op
+            spanTermQuery {
+                field = "title"
+                value = " "
+            }
+            // fallback
+            matchAll { it }
+        }
+
+        built.isMatchAll shouldBe true
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanWithinQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanWithinQueryTest.kt
@@ -1,0 +1,68 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+class SpanWithinQueryTest : FunSpec({
+
+    test("span_within: 기본 동작 및 속성 확인") {
+        val little = spanTermQuery("body", "green")
+        val big = spanNearQuery(
+            clauses = listOf(
+                spanTermQuery("body", "green"),
+                spanTermQuery("body", "apple")
+            ),
+            slop = 2,
+            inOrder = true
+        )
+
+        val q = spanWithinQuery(little = little, big = big, boost = 1.2f, _name = "within_green")
+        q shouldNotBe null
+        q!!.isSpanWithin shouldBe true
+        val sw = q.spanWithin()
+        sw.boost() shouldBe 1.2f
+        sw.queryName() shouldBe "within_green"
+        sw.little().isSpanTerm shouldBe true
+        sw.big().isSpanNear shouldBe true
+    }
+
+    test("span_within: 블록 DSL 동작 및 no-op fallback") {
+        val q = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query {
+            spanWithinQuery {
+                little { spanTermQuery("body", "green") }
+                big {
+                    spanNearQuery(
+                        clauses = listOf(
+                            spanTermQuery("body", "green"),
+                            spanTermQuery("body", "apple")
+                        ),
+                        slop = 1
+                    )
+                }
+                _name = "within_dsl"
+            }
+        }
+        q.isSpanWithin shouldBe true
+        q.spanWithin().queryName() shouldBe "within_dsl"
+
+        val fallback = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query {
+            spanWithinQuery {
+                // little/big 미설정 → no-op
+            }
+            matchAll { it }
+        }
+        fallback.isMatchAll shouldBe true
+    }
+
+    test("span_within: null/비-span 입력 시 null 반환") {
+        val q1 = spanWithinQuery(little = null, big = spanTermQuery("f", "v"))
+        q1 shouldBe null
+
+        val q2 = spanWithinQuery(little = spanTermQuery("f", "v"), big = null)
+        q2 shouldBe null
+
+        val q3 = spanWithinQuery(little = matchQuery("f", "v"), big = spanTermQuery("f", "v"))
+        q3 shouldBe null
+    }
+})


### PR DESCRIPTION
This pull request significantly expands and improves the documentation and Kotlin DSL support for Elasticsearch span queries, both in English (`README.md`) and Korean (`README.ko.md`). It introduces comprehensive usage examples, option tables, and test references for all major span query types. Additionally, it adds a new DSL class and builder extension for `span_term` queries in the Kotlin source.

**Documentation enhancements:**

* Added detailed sections for `span_term`, `span_or`, `span_within`, `span_not`, `span_containing`, `span_first`, and `span_multi` queries in both `README.md` and `README.ko.md`, with usage examples, option tables, and references to corresponding tests. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R203-R232) [[2]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR189-R218) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R318-R467) [[4]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR304-R453) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R581-R770) [[6]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR580-R769)

**Kotlin DSL improvements:**

* Introduced `SpanTermQueryDsl` class and the `spanTermQuery` extension for `Query.Builder`, enabling block-style DSL for span term queries. This allows for more idiomatic and flexible DSL usage.
* Updated imports in `SpanQueries.kt` to include all relevant Elasticsearch span query types, ensuring full type coverage for the new DSL features.

**Testing references:**

* All new and existing span query types in the documentation now reference their respective test files, improving discoverability and confidence in correctness. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R318-R467) [[2]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR304-R453) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R581-R770) [[4]](diffhunk://#diff-86fa6921bcebf260d55d8a3742c1b513bd78f4ea18366db989b5a03c68c563aeR580-R769)

These changes make the documentation much more comprehensive and user-friendly, and the DSL enhancements provide a better developer experience for constructing span queries in Kotlin.