### PR TITLE
54 specialized queries 추가 개발

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 ## 핵심 특징
 - **코틀린 친화적 API**: JSON 문자열 대신 빌더 패턴으로 쿼리를 작성합니다.
 - **안전한 생략 처리**: 불필요하거나 잘못된 입력을 자동으로 걸러냅니다.
-- **폭넓은 쿼리 지원**: 전문 검색, term-level, span, compound, script, wrapper, pinned, rule 등 다양한 Elasticsearch DSL을 커버합니다.
+- **폭넓은 쿼리 지원**: 전문 검색, term-level, span, compound, script, wrapper, pinned, rule, weighted_tokens 등 다양한 Elasticsearch DSL을 커버합니다.
 - **재사용 가능한 헬퍼**: `SubQueryBuilders`로 bool 절 내부에서도 간단히 하위 쿼리를 누적할 수 있습니다.
 - **테스트 검증**: Kotest + JUnit 5 스펙이 패키지 구조와 동일하게 구성되어 있어 예제와 검증을 동시에 제공합니다.
 
@@ -119,6 +119,21 @@ query {
             }
         }
         matchCriteria(mapOf("channel" to "web"))
+    }
+}
+
+// Weighted tokens 쿼리: 필드에 대해 가중 토큰을 제공
+query {
+    weightedTokensQuery {
+        field = "title.embedding"
+        tokens(
+            "kotlin" to 1.0,
+            "dsl" to 0.7
+        )
+        pruningConfig {
+            tokensFreqRatioThreshold = 3
+            tokensWeightThreshold = 0.2f
+        }
     }
 }
 ```

--- a/README.ko.md
+++ b/README.ko.md
@@ -7,7 +7,7 @@
 ## 핵심 특징
 - **코틀린 친화적 API**: JSON 문자열 대신 빌더 패턴으로 쿼리를 작성합니다.
 - **안전한 생략 처리**: 불필요하거나 잘못된 입력을 자동으로 걸러냅니다.
-- **폭넓은 쿼리 지원**: 전문 검색, term-level, span, compound, script, wrapper, pinned 등 다양한 Elasticsearch DSL을 커버합니다.
+- **폭넓은 쿼리 지원**: 전문 검색, term-level, span, compound, script, wrapper, pinned, rule 등 다양한 Elasticsearch DSL을 커버합니다.
 - **재사용 가능한 헬퍼**: `SubQueryBuilders`로 bool 절 내부에서도 간단히 하위 쿼리를 누적할 수 있습니다.
 - **테스트 검증**: Kotest + JUnit 5 스펙이 패키지 구조와 동일하게 구성되어 있어 예제와 검증을 동시에 제공합니다.
 
@@ -107,9 +107,23 @@ query {
         }
     }
 }
+
+// Rule 쿼리: 룰셋과 organic 쿼리를 매칭 기준과 함께 연결
+query {
+    ruleQueryDsl {
+        rulesetIds("featured")
+        organic {
+            matchQuery {
+                field = "status"
+                query = "active"
+            }
+        }
+        matchCriteria(mapOf("channel" to "web"))
+    }
+}
 ```
 
-그 외 `knnQuery`, `percolateQuery`, `rankFeatureQuery`, `distanceFeatureQuery` 등도 지원하며, 관련 예제는 `src/test/kotlin/.../queries/specialized`에서 확인할 수 있습니다.
+그 외 `knnQuery`, `percolateQuery`, `rankFeatureQuery`, `distanceFeatureQuery`, `ruleQuery` 등도 지원하며, 관련 예제는 `src/test/kotlin/.../queries/specialized`에서 확인할 수 있습니다.
 
 ## 테스트 & 품질 관리
 - 필요 시 `./gradlew test --tests "패키지.클래스"`로 특정 스펙만 실행하세요.

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,902 +2,125 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-코틀린 타입‑세이프 빌더로 Elasticsearch 쿼리를 동적으로 조합하는 DSL입니다. null/빈 입력은 자동 생략되어 출력 JSON을 간결하고 유효하게 유지합니다.
+타입 세이프 코틀린 DSL로 Elasticsearch 쿼리를 조합할 수 있는 라이브러리입니다. null/빈 값은 자동으로 제외되어 결과 JSON이 간결하고 유효하게 유지됩니다. English version is available in [`README.md`](README.md).
 
-영문 문서: README.md
+## 핵심 특징
+- **코틀린 친화적 API**: JSON 문자열 대신 빌더 패턴으로 쿼리를 작성합니다.
+- **안전한 생략 처리**: 불필요하거나 잘못된 입력을 자동으로 걸러냅니다.
+- **폭넓은 쿼리 지원**: 전문 검색, term-level, span, compound, script, wrapper, pinned 등 다양한 Elasticsearch DSL을 커버합니다.
+- **재사용 가능한 헬퍼**: `SubQueryBuilders`로 bool 절 내부에서도 간단히 하위 쿼리를 누적할 수 있습니다.
+- **테스트 검증**: Kotest + JUnit 5 스펙이 패키지 구조와 동일하게 구성되어 있어 예제와 검증을 동시에 제공합니다.
 
-## 주요 특징
-- 직관적 DSL: JSON 대신 코틀린 빌더 사용
-- 동적 생략: null/빈 값은 자동 제외
-- 전문 쿼리: match, match_phrase, match_bool_prefix, multi_match(type=phrase), combined_fields
-- 점수 조작: field value factor, script score, weight, random score, decay
-- Kotlin/JDK 17, Kotest + JUnit 5
+## 요구 사항
+- JDK 17
+- Gradle Wrapper (저장소에 포함)
 
-## 빠른 시작
-- 빌드/테스트: `./gradlew clean build`
-- 로컬 배포: `./gradlew publishToMavenLocal`
+## 시작하기
+```bash
+./gradlew clean build        # 전체 빌드 및 테스트
+./gradlew test               # 반복 개발 시 빠른 테스트
+./gradlew publishToMavenLocal # ~/.m2 로컬 배포
+```
 
-최소 예제
+### 최소 예제
 ```kotlin
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.*
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.*
 
 val q: Query = query {
-  boolQuery {
-    mustQuery {
-      queries[
-        { matchPhrase(field = "message", query = "this is a test") },
-        { matchPhrasePrefix(field = "path", query = "/api/ad") },
-        { combinedFields(query = "john smith", fields = listOf("first_name", "last_name")) }
-      ]
-    }
-  }
-}
-```
-
-## 간단 사용법
-- Bool + 절 구성
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.*
-
-val q = query {
-  boolQuery {
-    mustQuery { termQuery { field = "user.id"; value = "silbaram" } }
-    filterQuery { rangeQuery { field = "age"; gte = 20; lt = 30 } }
-    shouldQuery {
-      queries[
-        { termQuery { field = "tags"; value = "kotlin" } },
-        { termQuery { field = "tags"; value = "elasticsearch" } }
-      ]
-    }
-    mustNotQuery { existsQuery { field = "deleted_at" } }
-  }
-}
-
-### 배열형 DSL (queries[ ... ])
-절 블록 내부에서 여러 쿼리를 간결하게 추가할 때 배열형 빌더를 사용합니다. `query { ... }`로 감싸지 않아도 됩니다.
-
-```kotlin
-boolQuery {
-  mustQuery {
-    queries[
-      { termQuery { field = "tags"; value = "kotlin" } },
-      { combinedFields(query = "john smith", fields = listOf("first_name","last_name")) },
-      { rangeQuery { field = "age"; gte = 20; lt = 30 } }
-    ]
-  }
-}
-```
-
-참고
-- 빌더 람다와 미리 만들어진 `Query?` 둘 다 허용하며, 부적합한 입력은 자동 생략됩니다.
-- 일관성과 가독성을 위해 빌더 람다 사용을 권장합니다.
-```
-
-- 전문 검색 (한 줄 예시)
-```kotlin
-query { matchPhrase(field = "title", query = "exact order", slop = 1) }
-query { matchBoolPrefix(field = "title", query = "quick bro") }
-multiMatchPhraseQuery("kotlin coroutine", listOf("title^2", "description"))
-queryStringQuery("kotlin* AND \"structured query\"", listOf("title","body"))
-simpleQueryStringQuery("kotlin +coroutine | \"structured query\"", listOf("title","body"))
-```
-
-간단 JSON
-```json
-{ "query": { "bool": { "must": [{ "term": { "user.id": "silbaram" }}] } } }
-{ "query": { "match_phrase": { "title": { "query": "exact order", "slop": 1 } } } }
-{ "query": { "combined_fields": { "query": "john smith", "fields": ["first_name","last_name"], "operator": "and", "minimum_should_match": "2" } } }
-```
-
-### Multi‑match (일반형)
-`multiMatchQuery` 또는 `Query.Builder.multiMatch`를 사용합니다.
-
-```kotlin
-import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType
-import co.elastic.clients.elasticsearch._types.query_dsl.Operator
-
-multiMatchQuery(
-  query = "kotlin coroutine",
-  fields = listOf("title^2", "description"),
-  type = TextQueryType.BestFields,
-  operator = Operator.Or,
-  minimumShouldMatch = "2"
-)
-```
-
-JSON
-```json
-{ "query": { "multi_match": {
-  "query": "kotlin coroutine",
-  "fields": ["title^2", "description"],
-  "type": "best_fields",
-  "operator": "or",
-  "minimum_should_match": "2"
-} } }
-```
-
-테스트: [MultiMatchQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchQueryTest.kt)
-
-### Query string
-Lucene 질의 문법으로 여러 필드에 질의를 적용합니다.
-
-```kotlin
-import co.elastic.clients.elasticsearch._types.query_dsl.Operator
-
-queryStringQuery(
-  query = "title:(kotlin AND coroutine) AND body:tips",
-  fields = listOf("title^2","body"),
-  defaultOperator = Operator.And
-)
-```
-
-JSON
-```json
-{ "query": { "query_string": {
-  "query": "title:(kotlin AND coroutine) AND body:tips",
-  "fields": ["title^2","body"],
-  "default_operator": "and"
-} } }
-```
-
-테스트: [QueryStringQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/QueryStringQueryTest.kt)
-
-### Simple query string
-파싱 오류를 던지지 않는 관대한 문법으로, 지원되지 않는 구문은 무시됩니다.
-
-```kotlin
-simpleQueryStringQuery(
-  query = "kotlin +coroutine | \"structured query\"",
-  fields = listOf("title^2","body"),
-  // 자주 쓰는 옵션
-  defaultOperator = Operator.Or,
-  minimumShouldMatch = "2",
-  analyzeWildcard = true,
-  flags = listOf(SimpleQueryStringFlag.Prefix, SimpleQueryStringFlag.Phrase),
-  fuzzyMaxExpansions = 50,
-  fuzzyPrefixLength = 1,
-  fuzzyTranspositions = true
-)
-```
-
-JSON
-```json
-{ "query": { "simple_query_string": {
-  "query": "kotlin +coroutine | \"structured query\"",
-  "fields": ["title^2","body"],
-  "default_operator": "or",
-  "minimum_should_match": "2",
-  "analyze_wildcard": true,
-  "flags": "PREFIX|PHRASE",
-  "fuzzy_max_expansions": 50,
-  "fuzzy_prefix_length": 1,
-  "fuzzy_transpositions": true
-} } }
-```
-
-테스트: [SimpleQueryStringQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SimpleQueryStringQueryTest.kt)
-
-### More Like This
-유사 문서를 찾기 위한 쿼리입니다. 하나 이상의 `like` 항목(텍스트 또는 문서)이 필요하며, `unlike`로 제외 항목을 줄 수 있습니다. `like`가 비어있으면 쿼리는 생략됩니다.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-
-// 텍스트 기반
-val q1 = query {
-  mlt {
-    like { text("kotlin coroutine", "typed dsl") }
-    fields("title", "body")
-    analyzer = "standard"
-    minTermFreq = 1
-    maxQueryTerms = 25
-    minimumShouldMatch = "30%"
-    stopWords("a","the")
-    boost = 1.1f
-    _name = "mlt_text"
-  }
-}
-
-// 문서 기반 like/unlike 혼합 (index, id)
-val q2 = query {
-  mlt {
-    like { doc("articles", "1"); doc("articles", "2") }
-    unlike { text("legacy") }
-    fields("title")
-  }
-}
-
-// Bool 내부에서 사용 + 생략 동작
-val q3 = query {
-  boolQuery {
-    mustQuery {
-      // 생성됨
-      moreLikeThis { like { doc("articles", "1") }; fields("title") }
-      // 생략됨: like이 비어있음
-      moreLikeThis { /* no like */ }
-    }
-  }
-}
-```
-
-간단 JSON
-```json
-{ "query": { "more_like_this": {
-  "fields": ["title","body"],
-  "like": ["kotlin coroutine", "typed dsl"],
-  "min_term_freq": 1,
-  "max_query_terms": 25,
-  "minimum_should_match": "30%",
-  "stop_words": ["a","the"],
-  "boost": 1.1
-} } }
-```
-
-테스트: [MoreLikeThisQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MoreLikeThisQueryTest.kt)
-
-### 스팬 쿼리 (Span Queries)
-Elasticsearch 스팬 쿼리는 위치 기반 텍스트 매칭을 가능하게 합니다. 이 라이브러리는 함수형과 DSL 형태 모두를 지원하는 스팬 쿼리 DSL을 제공합니다.
-
-메모: 스팬 쿼리의 함수형 빌더는 deprecated 되었으며, `query { spanNearQuery { ... } }` 같은 DSL 사용을 권장합니다.
-
-#### 스팬 필드 마스킹 쿼리 (Span Field Masking Query)
-`span_field_masking` 쿼리는 서로 다른 필드의 스팬 쿼리들을 span-near나 span-or 쿼리에서 조합할 수 있도록 검색 필드를 "마스킹"합니다.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// DSL 형태 사용법
-val q = query {
-    spanFieldMaskingQuery {
-        query { spanTermQuery("text.stems", "fox") }
-        field = "text"
-        boost = 2.0f
-        _name = "mask-query"
-    }
-}
-```
-
-**동적 제외**: 잘못된 입력(null 쿼리, 빈 필드)에 대해 `null`을 반환하여 최종 DSL 출력에서 자동으로 필터링됩니다.
-
-#### 스팬 Term 쿼리 (Span Term Query)
-`span_term` 쿼리는 단일 용어의 위치 정보를 이용해 스팬 컨테이너와 조합 가능한 기본 스팬 절을 생성합니다.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// 블록 DSL
-val termDsl = query {
-    spanTermQuery {
-        field = "title"
-        value = "kotlin"
-        boost = 1.2f
-        _name = "term_kotlin"
-    }
-}
-```
-
-메모: `field` 또는 `value`가 비어있으면 생략(no-op)됩니다.
-
-테스트: [SpanTermQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanTermQueryTest.kt)
-
-#### 배열 스타일 DSL을 지원하는 스팬 Near 쿼리
-`span_near` 쿼리는 지정된 거리 내에서 스팬을 찾습니다. 이 구현은 전통적인 절 추가 방식과 배열 스타일 구문을 모두 지원합니다.
-
-```kotlin
-// 배열 스타일 DSL (권장)
-val nearQuery = query {
-    spanNearQuery {
-        clauses[
-            query { spanTermQuery { field = "text"; value = "quick" } },
-            query { spanFieldMaskingQuery { query { spanTermQuery("text.stems", "fox") }; field = "text" } }
-        ]
-        slop = 5
-        inOrder = false
-    }
-}
-
-// 대안: 개별 절 추가
-val nearQuery2 = query {
-    spanNearQuery {
-        clause(query { spanTermQuery { field = "text"; value = "quick" } })
-        clause(query { spanFieldMaskingQuery { query { spanTermQuery("text.stems", "fox") }; field = "text" } })
-        slop = 5
-        inOrder = false
-    }
-}
-```
-
-**주요 기능**:
-- **배열 스타일 구문**: `clauses[query1, query2, ...]`로 간결한 다중 절 정의
-- **개별 절 추가**: `clause(query)` 메서드로 점진적 쿼리 구축
-- **자동 스팬 변환**: 비-스팬 쿼리는 자동으로 필터링
-- **타입 안전성**: 유효한 스팬 쿼리만 허용
-
-**생성되는 JSON**:
-```json
-{
-  "span_near": {
-    "clauses": [
-      { "span_term": { "text": "quick" } },
-      {
-        "span_field_masking": {
-          "query": { "span_term": { "text.stems": "fox" } },
-          "field": "text"
-        }
-      }
-    ],
-    "slop": 5,
-    "in_order": false
-  }
-}
-```
-
-**통합 예제**: 복잡한 쿼리에서 스팬 필드 마스킹 사용
-```kotlin
-val complexQuery = query {
     boolQuery {
-        mustQuery {
-            spanNearQuery {
-                clauses[
-                    query { spanTermQuery { field = "content"; value = "elasticsearch" } },
-                    query { spanFieldMaskingQuery { query { spanTermQuery("content.stemmed", "kotlin") }; field = "content" } }
-                ]
-                slop = 10
-                inOrder = true
-            }
-        }
+        mustQuery { termQuery { field = "user.id"; value = "silbaram" } }
+        filterQuery { rangeQuery { field = "age"; gte = 20; lt = 35 } }
         shouldQuery {
-            query { matchQuery { field = "title"; query = "tutorial" } }
+            queries[
+                { termQuery { field = "tags"; value = "kotlin" } },
+                { termQuery { field = "tags"; value = "search" } }
+            ]
         }
+        mustNotQuery { existsQuery { field = "deleted_at" } }
     }
 }
 ```
 
-테스트: 
-- [SpanFieldMaskingQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanFieldMaskingQueryTest.kt)
-- [SpanFieldMaskingParityTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanFieldMaskingParityTest.kt)
-- [SpanNearQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanNearQueryTest.kt)
+## DSL 개요
+### 기본 패턴
+- 최상위는 `query { ... }` 또는 `queryOrNull { ... }` 를 사용합니다.
+- `mustQuery`, `filterQuery`, `shouldQuery`, `mustNotQuery` 등 절 전용 헬퍼로 서브 쿼리를 누적합니다.
+- `SubQueryBuilders`는 `termQuery`, `rangeQuery`, `matchQuery`, `scriptQuery`, `scriptScoreQuery`, `wrapperQuery`, `pinnedQuery` 등 자주 쓰는 빌더를 바로 노출합니다.
 
-#### 고급 조합 예제
-스팬 쿼리는 서로 자유롭게 중첩/조합할 수 있습니다. 아래는 자주 쓰는 패턴입니다.
+### 자주 쓰는 쿼리 빌더
+- **Term/Range**: `termQuery`, `termsQuery`, `rangeQuery`, `existsQuery`, `matchAllDsl`
+- **전문 검색**: `matchQuery`, `matchPhrase`, `matchPhrasePrefix`, `matchBoolPrefix`, `multiMatchQuery`, `combinedFields`, `queryString`, `simpleQueryString`
+- **Span/Interval**: `spanTermQuery`, `spanNearQuery`, `spanContainingQuery`, `intervals`
 
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
+세부 예제는 `src/test/kotlin/.../queries/{termlevel,fulltext,span}` 경로의 Kotest 스펙을 참고하세요.
 
-// 1) span_near + span_or 중첩
-val nearOr = query {
-    spanNearQuery {
-        clauses[
-            spanOrQuery(clauses = listOf(
-                spanTermQuery("title", "elasticsearch"),
-                spanTermQuery("title", "kotlin")
-            )),
-            spanTermQuery("title", "dsl")
-        ]
-        slop = 3
-        inOrder = false
-    }
-}
+### 컴파운드/스코어링 빌더
+- `boolQuery` + 절 헬퍼
+- `functionScore` (field value factor, script score, random score, weight 등)
+- `constantScore`, `boostingQuery`
 
-// 2) span_not(pre/post)으로 근접 배제
-val notClose = query {
-    spanNotQuery {
-        include {
-            spanNearQuery(
-                clauses = listOf(
-                    spanTermQuery("body", "green"),
-                    spanTermQuery("body", "apple")
-                ),
-                slop = 2
-            )
-        }
-        exclude { spanTermQuery("body", "rotten") }
-        pre = 0
-        post = 1
-        _name = "exclude_rotten"
-    }
-}
-
-// 3) span_field_masking으로 다른 분석 필드 조합
-val masked = query {
-    spanNearQuery {
-        clauses[
-            { spanTermQuery { field = "text"; value = "quick" } },
-            { spanFieldMaskingQuery { query { spanTermQuery("text.stems", "fox") }; field = "text" } }
-        ]
-        slop = 4
-    }
-}
-
-// 4) span_multi(range/prefix 등 멀티텀을 스팬으로 래핑)
-val withRange = query {
-    spanNearQuery {
-        clauses[
-            { spanTermQuery { field = "title"; value = "kotlin" } },
-            { spanMultiQuery { match { query { rangeQuery { field = "publish_date"; gte = "2024-01-01" } } } } }
-        ]
-        slop = 5
-    }
-}
-```
-
-#### 스팬 Or 쿼리 (Span Or Query)
-`span_or` 쿼리는 하나 이상의 스팬 절 중 임의의 하나라도 매칭되면 참으로 평가합니다.
+## 특수 쿼리 모음
+최근 추가된 스페셜 DSL은 다음과 같습니다.
 
 ```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// 함수형 사용법
-val orQuery = spanOrQuery(
-    clauses = listOf(
-        spanTermQuery("title", "kotlin"),
-        spanTermQuery("title", "dsl"),
-        spanNearQuery(
-            clauses = listOf(
-                spanTermQuery("title", "structured"),
-                spanTermQuery("title", "concurrency")
-            ),
-            slop = 1
+// Script 쿼리 (inline/stored 모두 지원)
+query {
+    scriptQuery {
+        inline(
+            source = "doc['votes'].value > params.threshold",
+            lang = "painless",
+            params = mapOf("threshold" to 10)
         )
-    ),
-    _name = "span_or_example"
-)
-
-// 블록 DSL
-val orDsl = query {
-    spanOrQuery {
-        clauses[
-            query { spanTermQuery { field = "title"; value = "kotlin" } },
-            query { spanTermQuery { field = "title"; value = "dsl" } }
-        ]
-        _name = "span_or_dsl"
+        boost = 1.2f
+        _name = "votes-script"
     }
 }
-```
 
-메모: 비‑스팬 쿼리는 자동 제외됩니다. 유효 절이 없으면 DSL은 no‑op로 동작합니다.
+// Script score 쿼리 (organic 기본값은 match_all)
+query {
+    scriptScoreQuery {
+        inline(source = "params.factor", params = mapOf("factor" to 2))
+        minScore = 0.5f
+    }
+}
 
-테스트: [SpanOrQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanOrQueryTest.kt)
+// Wrapper 쿼리: 원본 JSON 또는 base64 문자열 제공
+query {
+    wrapperQuery {
+        rawJson("""{"match":{"status":"active"}}""")
+    }
+}
 
-#### 스팬 Within 쿼리 (Span Within Query)
-`span_within` 쿼리는 작은 스팬(little)이 큰 스팬(big)의 범위 안에 완전히 포함될 때 매칭됩니다.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// DSL 사용 예
-val withinDsl = query {
-    spanWithinQuery {
-        little { query { spanTermQuery { field = "body"; value = "green" } } }
-        big {
-            query {
-                spanNearQuery {
-                    clauses[
-                        query { spanTermQuery { field = "body"; value = "green" } },
-                        query { spanTermQuery { field = "body"; value = "apple" } }
-                    ]
-                    slop = 2
-                    inOrder = true
-                }
+// Pinned 쿼리: 고정 문서와 일반 organic 쿼리 결합
+query {
+    pinnedQuery {
+        ids("1", "2", "3")
+        organic {
+            matchQuery {
+                field = "title"
+                query = "elasticsearch"
             }
         }
-        _name = "within_green"
-    }
-}
-
-// 블록 DSL
-val withinDsl = query {
-    spanWithinQuery {
-        little { spanTermQuery("body", "green") }
-        big {
-            spanNearQuery(
-                clauses = listOf(
-                    spanTermQuery("body", "green"),
-                    spanTermQuery("body", "apple")
-                ),
-                slop = 1
-            )
-        }
-        _name = "within_dsl"
     }
 }
 ```
 
-메모: `little`/`big`는 모두 스팬 쿼리여야 하며, 누락/비‑스팬 입력 시 DSL은 no‑op로 동작합니다.
+그 외 `knnQuery`, `percolateQuery`, `rankFeatureQuery`, `distanceFeatureQuery` 등도 지원하며, 관련 예제는 `src/test/kotlin/.../queries/specialized`에서 확인할 수 있습니다.
 
-테스트: [SpanWithinQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanWithinQueryTest.kt)
+## 테스트 & 품질 관리
+- 필요 시 `./gradlew test --tests "패키지.클래스"`로 특정 스펙만 실행하세요.
+- `./gradlew check`는 컴파일, 테스트, 추가 검증 작업을 한번에 수행합니다.
+- 모든 스펙은 `context`/`should` 형태로 작성되어 읽기 쉽고, 프로덕션 패키지 구조와 동일하게 배치되어 있습니다.
 
-- Combined fields
-```kotlin
-import co.elastic.clients.elasticsearch._types.query_dsl.CombinedFieldsOperator
-
-combinedFields(
-  query = "john smith",
-  fields = listOf("first_name", "last_name"),
-  operator = CombinedFieldsOperator.And,
-  minimumShouldMatch = "2"
-)
-```
-
-메모: `text` 필드를 사용하세요. null/빈 입력은 쿼리에서 생략됩니다.
-
-## Function Score
-함수별 필터, field value factor, weight, random, decay 등을 조합하세요.
-
-예시: decay 함수
-```kotlin
-val q = query {
-  functionScoreQuery {
-    // 기본 쿼리
-    query { termQuery { field = "status"; value = "active" } }
-
-    // 날짜 필드에 gauss decay 적용
-    function {
-      gaussDecayQuery(
-        field = "date",
-        origin = "now",
-        scale = "7d",
-        offset = "1d",
-        decay = 0.5
-      )
-    }
-
-    // 거리 필드에 linear decay 적용
-    function { linearDecayQuery(field = "distance", origin = "0km", scale = "10km") }
-
-    // weight / random과 조합
-    function { weight(0.5); randomScore(seed = "seed-1", field = "user_id") }
-
-    scoreMode("sum"); boostMode("multiply")
-  }
-}
-```
-
-테스트:
-- 기본: [FunctionScoreTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/FunctionScoreTest.kt)
-- Decay: [DecayFunctionTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/DecayFunctionTest.kt)
-
-## Distance Feature
-`distance_feature` 쿼리는 날짜/위치 기준점에 가까울수록 점수를 높여줍니다(필터링 X, 점수만 영향). 일반적으로 `bool` 조합 내에서 사용합니다.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized.*
-
-// DSL (date origin)
-val byRecency = query {
-  distanceFeatureQuery {
-    field = "production_date"
-    origin = "now"
-    pivot = "7d"
-    boost = 1.2f
-    _name = "date-recency-boost"
-  }
-}
-
-// DSL (geo origin)
-val byProximity = query {
-  distanceFeatureQuery {
-    field = "location"
-    origin(52.376, 4.894) // 위도, 경도
-    pivot = "2km"
-    _name = "geo-proximity"
-  }
-}
-```
-
-옵션
-- field: date 또는 geo_point 필드
-- origin: 날짜 문자열(예: `"now"`, `"2024-01-01"`) 또는 `origin(lat, lon)`으로 좌표 지정
-- pivot: date 필드는 기간(예: `"7d"`), geo 필드는 거리(예: `"2km"`)
-- boost: 선택 점수 가중치
-- _name: 선택 쿼리 이름
-
-메모
-- null/blank 입력은 생략되며, 유효하지 않은 입력은 no-op/null 처리됩니다.
-- 점수에만 영향하므로 필터링은 다른 쿼리와 조합해서 사용하세요.
-
-테스트: [DistanceFeatureQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/DistanceFeatureQueryTest.kt)
-
-## 프로젝트 구조
-- `src/main/kotlin`: DSL 및 쿼리 빌더
-- `src/test/kotlin`: Kotest 스펙(JUnit 5)
-- Gradle Kotlin DSL, JDK 17 툴체인
+## 기여 가이드
+1. Conventional Commit 규칙에 맞춘 브랜치를 생성하세요 (예: `feat/pinned-query`).
+2. 동작 변경 시 반드시 테스트를 추가하거나 수정합니다.
+3. PR 전 `./gradlew check`가 통과하는지 확인합니다.
+4. PR 본문에는 동기, DSL 사용 예시, 기대 JSON, 관련 이슈(`Fixes #123`)를 정리해 주세요.
 
 ## 라이선스
-Apache License 2.0 — LICENSE 참조.
-
-## 배포
-- 빌드/테스트: `./gradlew clean build`
-- 로컬 배포: `./gradlew publishToMavenLocal`
-의존성 예시
-```kotlin
-repositories { mavenLocal(); mavenCentral() }
-dependencies { implementation("com.github.silbaram:elasticsearch-dynamic-query-dsl:1.0-SNAPSHOT") }
-```
-
-## 고급 옵션 요약
-
-Combined fields (combined_fields)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `fields` | List<String> | 대상 필드(`^`로 가중치) |
-| `operator` | CombinedFieldsOperator | `And`/`Or` |
-| `minimumShouldMatch` | String | 예: `2`, `75%` |
-| `autoGenerateSynonymsPhraseQuery` | Boolean | 구문 동의어 생성 |
-| `boost` | Float | 가중치 |
-
-Multi‑match (일반형)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `type` | TextQueryType | `best_fields`, `most_fields`, `cross_fields`, `phrase(_prefix)`, `bool_prefix` |
-| `operator` | Operator | 토큰 결합 방식 |
-| `minimumShouldMatch` | String | 예: `2`, `75%` |
-| `analyzer` | String | 질의어 분석기 |
-| `slop` | Int | 구문 허용 간격 |
-| `tieBreaker` | Double | `best_fields` 블렌딩 |
-| `fuzziness` | String | `AUTO`, `1`, `2` |
-| `prefixLength`/`maxExpansions` | Int | 퍼지/프리픽스 제어 |
-| `lenient` | Boolean | 포맷 오류 무시 |
-| `zeroTermsQuery` | ZeroTermsQuery | `All` 또는 `None` |
-
-Query string
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `fields`/`defaultField` | List<String>/String | 대상/기본 필드 |
-| `analyzer`/`quoteAnalyzer` | String | 분석기 지정 |
-| `quoteFieldSuffix` | String | 따옴표 용어 접미사 |
-| `defaultOperator` | Operator | `And`/`Or` |
-| `allowLeadingWildcard` | Boolean | `*term` 허용(비용 큼) |
-| `analyzeWildcard` | Boolean | 와일드카드 분석 |
-| `fuzziness` | String | 퍼지 레벨 |
-| `fuzzyMaxExpansions`/`fuzzyPrefixLength` | Int | 퍼지 제어 |
-| `fuzzyTranspositions` | Boolean | 전치 허용 |
-| `minimumShouldMatch` | String | 예: `2`, `75%` |
-| `phraseSlop` | Double | 구문 간격 |
-| `lenient` | Boolean | 포맷 오류 무시 |
-
-Simple query string
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `fields` | List<String> | 대상 필드 |
-| `defaultOperator` | Operator | `And`/`Or` |
-| `analyzer` | String | 분석기 지정 |
-| `quoteFieldSuffix` | String | 따옴표 용어 접미사 |
-| `analyzeWildcard` | Boolean | 와일드카드 분석 |
-| `flags` | List<SimpleQueryStringFlag> | 예: `Prefix`, `Phrase`, `And`, `Or`, `All` |
-| `fuzzyMaxExpansions`/`fuzzyPrefixLength` | Int | 퍼지 제어 |
-| `fuzzyTranspositions` | Boolean | 전치 허용 |
-| `minimumShouldMatch` | String | 예: `2`, `75%` |
-| `lenient` | Boolean | 포맷 오류 무시 |
-
-### 스팬 쿼리 옵션
-
-스팬 필드 마스킹 쿼리 (span_field_masking)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `query` | SpanQuery | 필수. 마스킹할 스팬 쿼리 |
-| `field` | String | 필수. 마스킹할 대상 필드 |
-| `boost` | Float | 쿼리 부스트 팩터 |
-| `_name` | String | 디버깅용 쿼리 이름 |
-
-**동적 제외**: 잘못된 입력(null 쿼리, 빈 필드)에 대해 `null` 반환
-
-스팬 Near 쿼리 (span_near)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `clauses` | 배열/리스트 구문 | `clauses[query1, query2, ...]` 또는 `clause(query)` |
-| `slop` | Int | 필수. 스팬 간 최대 허용 거리 |
-| `inOrder` | Boolean | 절이 순서대로 나타나야 하는지 여부 |
-| `boost` | Float | 쿼리 부스트 팩터 |
-| `_name` | String | 디버깅용 쿼리 이름 |
-
-**사용 패턴**:
-- 배열 스타일: `clauses[spanTermQuery("field", "value"), ...]`
-- 개별 추가: `clause(spanTermQuery("field", "value"))`
-- 두 패턴 모두 비-스팬 쿼리는 자동 필터링
-
-스팬 Or 쿼리 (span_or)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `clauses` | 배열/리스트 | 스팬 쿼리만 허용, 비-스팬은 자동 제외 |
-| `boost` | Float | 쿼리 부스트 팩터 |
-| `_name` | String | 디버깅용 쿼리 이름 |
-
-스팬 Within 쿼리 (span_within)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `little` | SpanQuery | 필수. 작은 스팬(완전히 포함되어야 함) |
-| `big` | SpanQuery | 필수. 큰 스팬(포함 영역) |
-| `boost` | Float | 쿼리 부스트 팩터 |
-| `_name` | String | 디버깅용 쿼리 이름 |
-
-스팬 Not 쿼리 (span_not)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `include` | SpanQuery | 필수. 포함 대상 스팬 쿼리 |
-| `exclude` | SpanQuery | 필수. 제외 대상 스팬 쿼리 |
-| `pre` | Int | 0 이상. 앞쪽 인접 허용 거리 |
-| `post` | Int | 0 이상. 뒤쪽 인접 허용 거리 |
-| `boost` | Float | 쿼리 부스트 팩터 |
-| `_name` | String | 디버깅용 쿼리 이름 |
-
-스팬 Term 쿼리 (span_term)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `field` | String | 필수. 대상 필드 |
-| `value` | String | 필수. 검색어(공백/널 불가) |
-| `boost` | Float | 쿼리 부스트 팩터 |
-| `_name` | String | 디버깅용 쿼리 이름 |
-
-스팬 Containing 쿼리 (span_containing)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `little` | SpanQuery | 필수. 작은 스팬 |
-| `big` | SpanQuery | 필수. 큰 스팬(포함) |
-| `boost` | Float | 쿼리 부스트 팩터 |
-| `_name` | String | 디버깅용 쿼리 이름 |
-
-스팬 First 쿼리 (span_first)
-
-| 옵션 | 타입 | 비고 |
-|---|---|---|
-| `match` | SpanQuery | 필수. 매칭 스팬 |
-| `end` | Int | 필수. 시작 위치에서의 상한(포함 전까지) |
-| `boost` | Float | 쿼리 부스트 팩터 |
-| `_name` | String | 디버깅용 쿼리 이름 |
-
-**조합 예시**
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// span_term + span_near 조합
-val near = query {
-    spanNearQuery {
-        clauses[
-            spanTermQuery("title", "kotlin"),
-            spanTermQuery("title", "dsl")
-        ]
-        slop = 2
-        inOrder = true
-    }
-}
-
-// span_term + span_or 조합
-val orQ = query {
-    spanOrQuery {
-        clauses[
-            spanTermQuery("title", "kotlin"),
-            spanTermQuery("title", "coroutines")
-        ]
-    }
-}
-```
-
-테스트: [SpanNotQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanNotQueryTest.kt)
-
-## 기여하기
-
-기여를 환영합니다. 프로젝트 구조, 코딩 스타일, 테스트, PR 규칙은 [AGENTS.md](AGENTS.md)를 참고하세요.
-#### 스팬 Containing 쿼리 (Span Containing Query)
-`span_containing` 쿼리는 작은 스팬(little)을 포함하는 큰 스팬(big)이 있을 때 매칭합니다.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// 함수형 사용법
-val containing = spanContainingQuery(
-    little = spanTermQuery("body", "green"),
-    big = spanNearQuery(
-        clauses = listOf(
-            spanTermQuery("body", "green"),
-            spanTermQuery("body", "apple")
-        ),
-        slop = 2,
-        inOrder = true
-    ),
-    _name = "containing_green"
-)
-
-// 블록 DSL
-val containingDsl = query {
-    spanContainingQuery {
-        little { spanTermQuery("body", "green") }
-        big {
-            spanNearQuery(
-                clauses = listOf(
-                    spanTermQuery("body", "green"),
-                    spanTermQuery("body", "apple")
-                ),
-                slop = 1,
-                inOrder = true
-            )
-        }
-        _name = "containing_dsl"
-    }
-}
-```
-
-테스트: 
-- [SpanContainingDslTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanContainingDslTest.kt)
-- [SpanQueriesTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanQueriesTest.kt)
-
-#### 스팬 First 쿼리 (Span First Query)
-`span_first` 쿼리는 매칭 스팬이 필드의 시작 부분에서 지정한 위치(`end`) 이전에 나타나는 경우 매칭합니다.
-
-```kotlin
-// 함수형 사용법
-val first = spanFirstQuery {
-    match = spanTermQuery("user.id", "kimchy")
-    end = 3
-    boost = 1.2f
-    _name = "first_query"
-}
-
-// 블록 DSL (확장)
-val firstDsl = query {
-    spanFirstQueryDsl {
-        match { spanTermQuery("user.id", "kimchy") }
-        end = 3
-        boost = 1.2f
-        _name = "first_dsl"
-    }
-}
-```
-
-테스트: 
-- [SpanFirstQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanFirstQueryTest.kt)
-- [SpanFirstDslTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanFirstDslTest.kt)
-#### 스팬 Multi 쿼리 (Span Multi Query)
-`span_multi` 쿼리는 멀티텀 쿼리(prefix, wildcard, regexp, fuzzy, range 등)를 스팬으로 래핑해 다른 스팬 쿼리들과 조합할 수 있게 합니다.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.*
-
-// 함수형 사용법
-val sm = spanMultiQuery(
-    match = rangeQuery(
-        field = "publish_date",
-        gte = "2023-01-01"
-    ),
-    boost = 1.1f,
-    _name = "range-as-span"
-)
-
-// 블록 DSL
-val smDsl = query {
-    spanMultiQuery {
-        match { rangeQuery("publish_date", gte = "2023-01-01") }
-        boost = 2.0f
-        _name = "dsl-range-span"
-    }
-}
-```
-
-메모: `match`는 멀티텀 쿼리만 허용(prefix|wildcard|regexp|fuzzy|range). 그 외는 무시되어 no-op 처리됩니다.
-
-테스트: [SpanMultiQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanMultiQueryTest.kt)
+Apache License 2.0. 자세한 내용은 [LICENSE](LICENSE)를 참고하세요.

--- a/README.md
+++ b/README.md
@@ -2,855 +2,129 @@
 
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-Type-safe Kotlin DSL for building Elasticsearch queries dynamically. Compose queries with concise builders that omit null/blank inputs, keeping the emitted JSON minimal and valid.
+Type-safe Kotlin DSL for composing Elasticsearch queries. Builders omit null or blank inputs so that generated JSON stays minimal and valid. 한글 문서는 [`README.ko.md`](README.ko.md)에서 확인할 수 있습니다.
 
-Read this in Korean: README.ko.md
+## Highlights
+- **Fluent Kotlin API** – Prefer Kotlin builders over brittle JSON strings.
+- **Safe omission** – Invalid or empty values get dropped automatically.
+- **Rich coverage** – Full-text, term-level, span, compound, and specialized queries (percolate, KNN, script, script_score, wrapper, pinned, rank_feature, distance_feature).
+- **Composable helpers** – `SubQueryBuilders` utilities let you stack clauses without repetitive `query { ... }` blocks.
+- **Battle-tested** – Kotest + JUnit 5 specs mirror the production package layout.
 
-## Features
-- Intuitive DSL: Kotlin builders instead of raw JSON.
-- Dynamic omission: Skip invalid inputs automatically.
-- Full‑text helpers: match, match_phrase, match_bool_prefix, multi_match(type=phrase), combined_fields.
-- Function score: field value factor, script score, weight, random score, decay.
-- Kotlin/JDK 17; Kotest + JUnit 5.
+## Requirements
+- JDK 17
+- Gradle Wrapper (provided)
 
-## Quick Start
-- Build/test: `./gradlew clean build`
-- Publish locally: `./gradlew publishToMavenLocal`
+## Getting Started
+```bash
+./gradlew clean build        # compile + full test suite
+./gradlew test               # iterative feedback with Kotest/JUnit
+./gradlew publishToMavenLocal # install DSL into ~/.m2 for local experiments
+```
 
-Minimal example
+### Minimal Example
 ```kotlin
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.*
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.*
 
 val q: Query = query {
-  boolQuery {
-    mustQuery {
-      queries[
-        { matchPhrase(field = "message", query = "this is a test") },
-        { matchPhrasePrefix(field = "path", query = "/api/ad") },
-        { combinedFields(query = "john smith", fields = listOf("first_name", "last_name")) }
-      ]
-    }
-  }
-}
-```
-
-## Usage (brief)
-- Bool + clauses
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.*
-
-val q = query {
-  boolQuery {
-    mustQuery { termQuery { field = "user.id"; value = "silbaram" } }
-    filterQuery { rangeQuery { field = "age"; gte = 20; lt = 30 } }
-    shouldQuery {
-      queries[
-        { termQuery { field = "tags"; value = "kotlin" } },
-        { termQuery { field = "tags"; value = "elasticsearch" } }
-      ]
-    }
-    mustNotQuery { existsQuery { field = "deleted_at" } }
-  }
-}
-```
-
-- Full‑text (one‑liners)
-```kotlin
-query { matchPhrase(field = "title", query = "exact order", slop = 1) }
-query { matchBoolPrefix(field = "title", query = "quick bro") }
-multiMatchPhraseQuery("kotlin coroutine", listOf("title^2", "description"))
-queryStringQuery("kotlin* AND \"structured query\"", listOf("title","body"))
-simpleQueryStringQuery("kotlin +coroutine | \"structured query\"", listOf("title","body"))
-```
-
-Small JSON
-```json
-{ "query": { "bool": { "must": [{ "term": { "user.id": "silbaram" }}] } } }
-{ "query": { "match_phrase": { "title": { "query": "exact order", "slop": 1 } } } }
-{ "query": { "combined_fields": { "query": "john smith", "fields": ["first_name","last_name"], "operator": "and", "minimum_should_match": "2" } } }
-```
-
-### Multi‑match (general)
-Apply a single query string across multiple fields; use `multiMatchQuery` or `Query.Builder.multiMatch`. Supports types: `best_fields`, `most_fields`, `cross_fields`, `phrase(_prefix)`, `bool_prefix`.
-
-```kotlin
-import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType
-import co.elastic.clients.elasticsearch._types.query_dsl.Operator
-
-multiMatchQuery(
-  query = "kotlin coroutine",
-  fields = listOf("title^2", "description"),
-  type = TextQueryType.BestFields,
-  operator = Operator.Or,
-  minimumShouldMatch = "2"
-)
-```
-
-JSON
-```json
-{ "query": { "multi_match": {
-  "query": "kotlin coroutine",
-  "fields": ["title^2", "description"],
-  "type": "best_fields",
-  "operator": "or",
-  "minimum_should_match": "2"
-} } }
-```
-
-See tests: [MultiMatchQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchQueryTest.kt)
-
-- Combined fields
-```kotlin
-import co.elastic.clients.elasticsearch._types.query_dsl.CombinedFieldsOperator
-
-combinedFields(
-  query = "john smith",
-  fields = listOf("first_name", "last_name"),
-  operator = CombinedFieldsOperator.And,
-  minimumShouldMatch = "2"
-)
-```
-
-Notes: Use text fields; null/blank inputs are omitted.
-
-### Query string
-Lucene query syntax across one or multiple fields. Supports quoted-field analyzer/suffix, wildcards (with `analyzeWildcard`/`allowLeadingWildcard`), fuzziness and phrase slop.
-
-```kotlin
-import co.elastic.clients.elasticsearch._types.query_dsl.Operator
-
-queryStringQuery(
-  query = "title:(kotlin AND coroutine) AND body:tips",
-  fields = listOf("title^2","body"),
-  defaultOperator = Operator.And
-)
-```
-
-JSON
-```json
-{ "query": { "query_string": {
-  "query": "title:(kotlin AND coroutine) AND body:tips",
-  "fields": ["title^2","body"],
-  "default_operator": "and"
-} } }
-```
-
-See tests: [QueryStringQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/QueryStringQueryTest.kt)
-
-### Simple query string
-Forgiving Lucene-like syntax that never throws on parse; unsupported/invalid parts are skipped. Supports flags (e.g., `Prefix`, `Phrase`, `And`, `Or`, `All`).
-
-```kotlin
-simpleQueryStringQuery(
-  query = "kotlin +coroutine | \"structured query\"",
-  fields = listOf("title^2","body"),
-  // common options
-  defaultOperator = Operator.Or,
-  minimumShouldMatch = "2",
-  analyzeWildcard = true,
-  flags = listOf(SimpleQueryStringFlag.Prefix, SimpleQueryStringFlag.Phrase),
-  fuzzyMaxExpansions = 50,
-  fuzzyPrefixLength = 1,
-  fuzzyTranspositions = true
-)
-```
-
-JSON
-```json
-{ "query": { "simple_query_string": {
-  "query": "kotlin +coroutine | \"structured query\"",
-  "fields": ["title^2","body"],
-  "default_operator": "or",
-  "minimum_should_match": "2",
-  "analyze_wildcard": true,
-  "flags": "PREFIX|PHRASE",
-  "fuzzy_max_expansions": 50,
-  "fuzzy_prefix_length": 1,
-  "fuzzy_transpositions": true
-} } }
-```
-
-See tests: [SimpleQueryStringQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SimpleQueryStringQueryTest.kt)
-
-### More Like This
-Find documents similar to given texts and/or documents. Requires at least one `like` item. Inputs that are null/blank are omitted; an empty `like` set results in omission.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-
-// Text-based
-val q1 = query {
-  mlt {
-    like { text("kotlin coroutine", "typed dsl") }
-    fields("title", "body")
-    analyzer = "standard"
-    minTermFreq = 1
-    maxQueryTerms = 25
-    minimumShouldMatch = "30%"
-    stopWords("a", "the")
-    boost = 1.1f
-    _name = "mlt_text"
-  }
-}
-
-// Mixed like/unlike (documents and texts)
-val q2 = query {
-  mlt {
-    like { doc("articles", "1"); doc("articles", "2") }
-    unlike { text("legacy") }
-    fields("title")
-  }
-}
-
-// In bool with omission behavior
-val q3 = query {
-  boolQuery {
-    mustQuery {
-      moreLikeThis { like { doc("articles", "1") }; fields("title") }
-      moreLikeThis { /* no like → omitted */ }
-    }
-  }
-}
-```
-
-JSON
-```json
-{ "query": { "more_like_this": {
-  "fields": ["title","body"],
-  "like": ["kotlin coroutine", "typed dsl"],
-  "min_term_freq": 1,
-  "max_query_terms": 25,
-  "minimum_should_match": "30%",
-  "stop_words": ["a","the"],
-  "boost": 1.1
-} } }
-```
-
-See tests: [MoreLikeThisQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MoreLikeThisQueryTest.kt)
-
-### Span Queries
-Elasticsearch span queries enable position-aware text matching. This library provides DSL support for span queries with both function-style and DSL-style syntax.
-
-Note: Function-style span builders are deprecated. Prefer DSL usage like `query { spanNearQuery { ... } }`.
-
-#### Span Field Masking Query
-The `span_field_masking` query allows span queries from different fields to be combined in span-near or span-or queries by "masking" the search field.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// DSL-style usage
-val q = query {
-    spanFieldMaskingQuery {
-        query { spanTermQuery("text.stems", "fox") }
-        field = "text"
-        boost = 2.0f
-        _name = "mask-query"
-    }
-}
-```
-
-**Dynamic Exclusion**: Returns `null` for invalid inputs (null query, blank field), automatically filtered from final DSL output.
-
-#### Span Term Query
-The `span_term` query builds a basic span clause for a single term, suitable for composing within other span containers.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-val termDsl = query {
-    spanTermQuery {
-        field = "title"
-        value = "kotlin"
-        boost = 1.2f
-        _name = "term_kotlin"
-    }
-}
-```
-
-Note: If `field` or `value` is blank, the query is omitted (no-op).
-
-See tests: [SpanTermQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanTermQueryTest.kt)
-
-#### Span Near Query with Array-Style DSL
-The `span_near` query finds spans within a specified distance. This implementation supports both traditional clause addition and array-style syntax.
-
-```kotlin
-// Array-style DSL (recommended)
-val nearQuery = query {
-    spanNearQuery {
-        clauses[
-            query { spanTermQuery { field = "text"; value = "quick" } },
-            query { spanFieldMaskingQuery { query { spanTermQuery("text.stems", "fox") }; field = "text" } }
-        ]
-        slop = 5
-        inOrder = false
-    }
-}
-
-// Alternative: Individual clause addition
-val nearQuery2 = query {
-    spanNearQuery {
-        clause(query { spanTermQuery { field = "text"; value = "quick" } })
-        clause(query { spanFieldMaskingQuery { query { spanTermQuery("text.stems", "fox") }; field = "text" } })
-        slop = 5
-        inOrder = false
-    }
-}
-```
-
-**Key Features**:
-- **Array-style syntax**: `clauses[query1, query2, ...]` for concise multi-clause definition
-- **Individual clause addition**: `clause(query)` method for building queries incrementally
-- **Automatic span conversion**: Non-span queries are automatically filtered out
-- **Type safety**: Only valid span queries are accepted
-
-**Generated JSON**:
-```json
-{
-  "span_near": {
-    "clauses": [
-      { "span_term": { "text": "quick" } },
-      {
-        "span_field_masking": {
-          "query": { "span_term": { "text.stems": "fox" } },
-          "field": "text"
-        }
-      }
-    ],
-    "slop": 5,
-    "in_order": false
-  }
-}
-```
-
-**Integration Example**: Using span field masking in complex queries
-```kotlin
-val complexQuery = query {
     boolQuery {
         mustQuery {
-            spanNearQuery {
-                clauses[
-                    spanTermQuery("content", "elasticsearch"),
-                    spanFieldMaskingQuery(
-                        query = spanTermQuery("content.stemmed", "kotlin"),
-                        field = "content"
-                    )
-                ]
-                slop = 10
-                inOrder = true
-            }
+            termQuery { field = "user.id"; value = "silbaram" }
+        }
+        filterQuery {
+            rangeQuery { field = "age"; gte = 20; lt = 35 }
         }
         shouldQuery {
-            query { matchQuery { field = "title"; query = "tutorial" } }
+            queries[
+                { termQuery { field = "tags"; value = "kotlin" } },
+                { termQuery { field = "tags"; value = "search" } }
+            ]
         }
     }
 }
 ```
 
-See tests: 
-- [SpanFieldMaskingQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFieldMaskingQueryTest.kt)
-- [SpanFieldMaskingParityTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanFieldMaskingParityTest.kt)
-- [SpanNearQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SpanNearQueryTest.kt)
+## DSL Overview
+### Core Patterns
+- Build top-level queries with `query { ... }` or `queryOrNull { ... }` (omits invalid content).
+- Use clause helpers (`mustQuery`, `filterQuery`, `shouldQuery`, `mustNotQuery`) to aggregate sub-queries.
+- `SubQueryBuilders` exposes inline helpers such as `termQuery`, `rangeQuery`, `matchQuery`, `scriptQuery`, `scriptScoreQuery`, `wrapperQuery`, `pinnedQuery`, etc.
 
-#### Advanced Combinations
-Span queries can be nested and combined freely. Common patterns include:
+### Term & Full-text Helpers
+- `termQuery`, `termsQuery`, `rangeQuery`, `existsQuery`, `matchAllDsl`
+- `matchQuery`, `matchPhrase`, `matchPhrasePrefix`, `matchBoolPrefix`
+- `multiMatchQuery`, `combinedFields`, `queryString`, `simpleQueryString`
+- `moreLikeThis`, `intervals`, and span DSL (`spanTermQuery`, `spanNearQuery`, ...)
+
+See the test suite under `src/test/kotlin/.../queries/{termlevel,fulltext,span}` for end-to-end samples.
+
+### Compound Builders
+- `boolQuery` with clause helpers
+- `functionScore` (field value factor, script score, random score, weight)
+- `constantScore`, `boostingQuery`
+
+## Specialized Queries
+Recent additions extend the DSL beyond core helpers:
 
 ```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// 1) span_near + span_or nesting
-val nearOr = query {
-    spanNearQuery {
-        clauses[
-            {
-                spanOrQuery {
-                    clauses[
-                        { spanTermQuery { field = "title"; value = "elasticsearch" } },
-                        { spanTermQuery { field = "title"; value = "kotlin" } }
-                    ]
-                }
-            },
-            { spanTermQuery { field = "title"; value = "dsl" } }
-        ]
-        slop = 3
-        inOrder = false
+// Script query (inline or stored)
+query {
+    scriptQuery {
+        inline(
+            source = "doc['votes'].value > params.threshold",
+            lang = "painless",
+            params = mapOf("threshold" to 10)
+        )
+        boost = 1.2f
+        _name = "votes-script"
     }
 }
 
-// 2) span_not with pre/post to exclude close terms
-val notClose = query {
-    spanNotQuery {
-        include {
-            spanNearQuery {
-                clauses[
-                    { spanTermQuery { field = "body"; value = "green" } },
-                    { spanTermQuery { field = "body"; value = "apple" } }
-                ]
-                slop = 2
+// Script score query with default organic match_all
+query {
+    scriptScoreQuery {
+        inline(source = "params.factor", params = mapOf("factor" to 2))
+        minScore = 0.5f
+    }
+}
+
+// Wrapper query: supply raw JSON or pre-encoded payload
+query {
+    wrapperQuery {
+        rawJson("""{"match":{"status":"active"}}""")
+    }
+}
+
+// Pinned query combining curated ids with an organic fallback
+query {
+    pinnedQuery {
+        ids("1", "2", "3")
+        organic {
+            matchQuery {
+                field = "title"
+                query = "elasticsearch"
             }
         }
-        exclude { spanTermQuery { field = "body"; value = "rotten" } }
-        pre = 0
-        post = 1
-        _name = "exclude_rotten"
-    }
-}
-
-// 3) span_field_masking to combine differently analyzed fields
-val masked = query {
-    spanNearQuery {
-        clauses[
-            { spanTermQuery { field = "text"; value = "quick" } },
-            { spanFieldMaskingQuery { query { spanTermQuery("text.stems", "fox") }; field = "text" } }
-        ]
-        slop = 4
-    }
-}
-
-// 4) span_multi to wrap multi-term queries (range/prefix/etc)
-val withRange = query {
-    spanNearQuery {
-        clauses[
-            query { spanTermQuery { field = "title"; value = "kotlin" } },
-            query { spanMultiQuery { match { query { rangeQuery { field = "publish_date"; gte = "2024-01-01" } } } } }
-        ]
-        slop = 5
     }
 }
 ```
 
-#### Span Or Query
-The `span_or` query matches if any of the provided span clauses match.
+Other specialized builders include `knnQuery`, `percolateQuery`, `rankFeatureQuery`, `distanceFeatureQuery`, and span integrations. Each has focused specs in `src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized`.
 
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-val orDsl = query {
-    spanOrQuery {
-        clauses[
-            query { spanTermQuery { field = "title"; value = "kotlin" } },
-            query { spanTermQuery { field = "title"; value = "dsl" } }
-        ]
-        _name = "span_or_dsl"
-    }
-}
-```
-
-Note: Non-span queries are filtered automatically. If no valid clauses remain, the DSL behaves as a no-op.
-
-See tests: [SpanOrQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanOrQueryTest.kt)
-
-#### Span Within Query
-The `span_within` query matches when the little span is entirely contained within the big span.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// Function-style
-val within = spanWithinQuery(
-    little = spanTermQuery("body", "green"),
-    big = spanNearQuery(
-        clauses = listOf(
-            spanTermQuery("body", "green"),
-            spanTermQuery("body", "apple")
-        ),
-        slop = 2,
-        inOrder = true
-    ),
-    _name = "within_green"
-)
-
-// DSL-style
-val withinDsl = query {
-    spanWithinQuery {
-        little { spanTermQuery("body", "green") }
-        big {
-            spanNearQuery(
-                clauses = listOf(
-                    spanTermQuery("body", "green"),
-                    spanTermQuery("body", "apple")
-                ),
-                slop = 1
-            )
-        }
-        _name = "within_dsl"
-    }
-}
-```
-
-Note: Both `little` and `big` must be valid span queries; if either is missing or non-span, the DSL behaves as a no-op.
-
-See tests: [SpanWithinQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanWithinQueryTest.kt)
-
-## Function Score
-Compose per‑function filters, field value factor, weight, random, and decay.
-
-Example: decay functions
-```kotlin
-val q = query {
-  functionScoreQuery {
-    // base query
-    query { termQuery { field = "status"; value = "active" } }
-
-    // gauss decay on date field
-    function {
-      gaussDecayQuery(
-        field = "date",
-        origin = "now",
-        scale = "7d",
-        offset = "1d",
-        decay = 0.5
-      )
-    }
-
-    // linear decay on distance field
-    function { linearDecayQuery(field = "distance", origin = "0km", scale = "10km") }
-
-    // combine with weight / random
-    function { weight(0.5); randomScore(seed = "seed-1", field = "user_id") }
-
-    scoreMode("sum"); boostMode("multiply")
-  }
-}
-```
-
-See tests:
-- Core: [FunctionScoreTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/FunctionScoreTest.kt)
-- Kibana‑like: merged into [FunctionScoreTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/FunctionScoreTest.kt)
-- Decay: [DecayFunctionTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/DecayFunctionTest.kt)
-
-## Project Structure
-- `src/main/kotlin`: Core DSL and query builders.
-- `src/test/kotlin`: Kotest specs on JUnit 5.
-- Gradle Kotlin DSL; JDK 17 toolchain.
-
-## License
-Apache License 2.0 — see LICENSE.
-
-## Badges & Release
-- Build/test: `./gradlew clean build`
-- Publish to Maven Local: `./gradlew publishToMavenLocal`
-- Dependency (example)
-```kotlin
-repositories { mavenLocal(); mavenCentral() }
-dependencies { implementation("com.github.silbaram:elasticsearch-dynamic-query-dsl:1.0-SNAPSHOT") }
-```
-
-## Advanced Options Summary
-
-Combined fields (combined_fields)
-
-| Option | Type | Notes |
-|---|---|---|
-| `fields` | List<String> | Target fields (weights via `^`) |
-| `operator` | CombinedFieldsOperator | `And` or `Or` |
-| `minimumShouldMatch` | String | e.g., `2`, `75%` |
-| `autoGenerateSynonymsPhraseQuery` | Boolean | Phrase synonyms |
-| `boost` | Float | Weight |
-
-Multi‑match (general)
-
-| Option | Type | Notes |
-|---|---|---|
-| `type` | TextQueryType | `best_fields`, `most_fields`, `cross_fields`, `phrase(_prefix)`, `bool_prefix` |
-| `operator` | Operator | Token combine mode |
-| `minimumShouldMatch` | String | e.g., `2`, `75%` |
-| `analyzer` | String | Query analyzer |
-| `slop` | Int | Phrase slack |
-| `tieBreaker` | Double | `best_fields` blending |
-| `fuzziness` | String | `AUTO`, `1`, `2` |
-| `prefixLength`/`maxExpansions` | Int | Fuzzy/prefix controls |
-| `lenient` | Boolean | Ignore format errors |
-| `zeroTermsQuery` | ZeroTermsQuery | `All` or `None` |
-
-Query string
-
-| Option | Type | Notes |
-|---|---|---|
-| `fields`/`defaultField` | List<String>/String | Target fields / default |
-| `analyzer`/`quoteAnalyzer` | String | Analyzer overrides |
-| `quoteFieldSuffix` | String | Suffix for quoted terms |
-| `defaultOperator` | Operator | `And`/`Or` |
-| `allowLeadingWildcard` | Boolean | Enable `*term` (expensive) |
-| `analyzeWildcard` | Boolean | Analyze wildcards |
-| `fuzziness` | String | Fuzzy level |
-| `fuzzyMaxExpansions`/`fuzzyPrefixLength` | Int | Fuzzy controls |
-| `fuzzyTranspositions` | Boolean | Fuzzy transpositions |
-| `minimumShouldMatch` | String | e.g., `2`, `75%` |
-| `phraseSlop` | Double | Phrase slack |
-| `lenient` | Boolean | Ignore format errors |
-
-Simple query string
-
-| Option | Type | Notes |
-|---|---|---|
-| `fields` | List<String> | Target fields |
-| `defaultOperator` | Operator | `And`/`Or` |
-| `analyzer` | String | Analyzer override |
-| `quoteFieldSuffix` | String | Suffix for quoted terms |
-| `analyzeWildcard` | Boolean | Analyze wildcards |
-| `flags` | List<SimpleQueryStringFlag> | e.g., `Prefix`, `Phrase`, `And`, `Or`, `All` |
-| `fuzzyMaxExpansions`/`fuzzyPrefixLength` | Int | Fuzzy controls |
-| `fuzzyTranspositions` | Boolean | Fuzzy transpositions |
-| `minimumShouldMatch` | String | e.g., `2`, `75%` |
-| `lenient` | Boolean | Ignore format errors |
-
-### Span Queries Options
-
-Span Field Masking Query (span_field_masking)
-
-| Option | Type | Notes |
-|---|---|---|
-| `query` | SpanQuery | Required. The span query to mask |
-| `field` | String | Required. Target field for masking |
-| `boost` | Float | Query boost factor |
-| `_name` | String | Query name for debugging |
-
-**Dynamic Exclusion**: Returns `null` for invalid inputs (null query, blank field)
-
-Span Near Query (span_near)
-
-| Option | Type | Notes |
-|---|---|---|
-| `clauses` | Array/List syntax | `clauses[query1, query2, ...]` or `clause(query)` |
-| `slop` | Int | Required. Maximum allowed distance between spans |
-| `inOrder` | Boolean | Whether clauses must appear in order |
-| `boost` | Float | Query boost factor |
-| `_name` | String | Query name for debugging |
-
-**Usage Patterns**:
-- Array-style: `clauses[spanTermQuery("field", "value"), ...]`
-- Individual: `clause(spanTermQuery("field", "value"))`
-- Both patterns automatically filter non-span queries
-
-Span Or Query (span_or)
-
-| Option | Type | Notes |
-|---|---|---|
-| `clauses` | Array/List | Span-only; non-span inputs are filtered |
-| `boost` | Float | Query boost factor |
-| `_name` | String | Query name for debugging |
-
-Span Within Query (span_within)
-
-| Option | Type | Notes |
-|---|---|---|
-| `little` | SpanQuery | Required. The inner (contained) span |
-| `big` | SpanQuery | Required. The outer (containing) span |
-| `boost` | Float | Query boost factor |
-| `_name` | String | Query name for debugging |
-
-Span Not Query (span_not)
-
-| Option | Type | Notes |
-|---|---|---|
-| `include` | SpanQuery | Required. The included span query |
-| `exclude` | SpanQuery | Required. The excluded span query |
-| `pre` | Int | >= 0. Max tokens allowed before include |
-| `post` | Int | >= 0. Max tokens allowed after include |
-| `boost` | Float | Query boost factor |
-| `_name` | String | Query name for debugging |
-
-See tests: [SpanNotQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanNotQueryTest.kt)
-
-Span Term Query (span_term)
-
-| Option | Type | Notes |
-|---|---|---|
-| `field` | String | Required. Target field |
-| `value` | String | Required. Term value (non-blank) |
-| `boost` | Float | Query boost factor |
-| `_name` | String | Query name for debugging |
-
-Span Containing Query (span_containing)
-
-| Option | Type | Notes |
-|---|---|---|
-| `little` | SpanQuery | Required. The inner (contained) span |
-| `big` | SpanQuery | Required. The outer (containing) span |
-| `boost` | Float | Query boost factor |
-| `_name` | String | Query name for debugging |
-
-Span First Query (span_first)
-
-| Option | Type | Notes |
-|---|---|---|
-| `match` | SpanQuery | Required. The span to match |
-| `end` | Int | Required. Upper bound position from start |
-| `boost` | Float | Query boost factor |
-| `_name` | String | Query name for debugging |
-
-**Combining examples**
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// span_term + span_near
-val near = query {
-    spanNearQuery {
-        clauses[
-            query { spanTermQuery { field = "title"; value = "kotlin" } },
-            query { spanTermQuery { field = "title"; value = "dsl" } }
-        ]
-        slop = 2
-        inOrder = true
-    }
-}
-
-// span_term + span_or
-val orQ = query {
-    spanOrQuery {
-        clauses[
-            query { spanTermQuery { field = "title"; value = "kotlin" } },
-            query { spanTermQuery { field = "title"; value = "coroutines" } }
-        ]
-    }
-}
-```
+## Testing & Quality
+- Run targeted suites via Gradle’s `--tests` flag when iterating.
+- `./gradlew check` executes compilation, tests, and additional verification tasks.
+- Kotest specs use descriptive `context/should` blocks and mirror production packages for easy discovery.
 
 ## Contributing
+1. Create a feature branch following Conventional Commit scopes (e.g., `feat/pinned-query`).
+2. Add or update tests for any behavioural change.
+3. Ensure `./gradlew check` passes before opening a PR.
+4. Summarize motivation, DSL snippets, and expected JSON in the PR body. Link issues with `Fixes #123` when applicable.
 
-Contributions are welcome. Please read the contributor guide in [AGENTS.md](AGENTS.md) for project structure, coding style, testing, and PR conventions.
-
-### Distance Feature Query
-The `distance_feature` query boosts documents based on proximity to a date or geo origin. It affects score only and is commonly combined inside `bool` queries.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized.*
-
-// DSL-style (date origin)
-val byRecency = query {
-  distanceFeatureQuery {
-    field = "production_date"
-    origin = "now"
-    pivot = "7d"
-    boost = 1.2f
-    _name = "date-recency-boost"
-  }
-}
-
-// DSL-style (geo origin)
-val byProximity = query {
-  distanceFeatureQuery {
-    field = "location"
-    origin(52.376, 4.894) // lat, lon
-    pivot = "2km"
-    _name = "geo-proximity"
-  }
-}
-```
-
-Options
-- field: date or geo_point field
-- origin: date string (e.g., `"now"`, `"2024-01-01"`) or geo coordinates via `origin(lat, lon)`
-- pivot: time (e.g., `"7d"`) for date fields, distance (e.g., `"2km"`) for geo fields
-- boost: optional score factor
-- _name: optional query name
-
-Notes
-- Null/blank inputs are omitted; invalid inputs result in no-op/null
-- Scoring only; combine with other queries for filtering
-
-See tests: [DistanceFeatureQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/DistanceFeatureQueryTest.kt)
-#### Span Containing Query
-The `span_containing` query matches when the big span fully contains the little span.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-
-// DSL-style
-val containingDsl = query {
-    spanContainingQuery {
-        little { query { spanTermQuery { field = "body"; value = "green" } } }
-        big { query { spanNearQuery { clauses[
-            query { spanTermQuery { field = "body"; value = "green" } },
-            query { spanTermQuery { field = "body"; value = "apple" } }
-        ]; slop = 1; inOrder = true } } }
-        _name = "containing_dsl"
-    }
-}
-```
-
-See tests:
-- [SpanContainingDslTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanContainingDslTest.kt)
-- [SpanQueriesTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanQueriesTest.kt)
-
-#### Span First Query
-The `span_first` query matches when the span occurs before a specified position (`end`) in the field.
-
-```kotlin
-// DSL-style
-val firstDsl = query {
-    spanFirstQueryDsl {
-        match { query { spanTermQuery { field = "user.id"; value = "kimchy" } } }
-        end = 3
-        boost = 1.2f
-        _name = "first_dsl"
-    }
-}
-```
-
-See tests:
-- [SpanFirstQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanFirstQueryTest.kt)
-- [SpanFirstDslTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanFirstDslTest.kt)
-#### Span Multi Query
-The `span_multi` query wraps a multi-term query (prefix, wildcard, regexp, fuzzy, range) as a span so it can be combined with other span queries.
-
-```kotlin
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span.*
-import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.*
-
-// Function-style
-val sm = spanMultiQuery(
-    match = rangeQuery(
-        field = "publish_date",
-        gte = "2023-01-01"
-    ),
-    boost = 1.1f,
-    _name = "range-as-span"
-)
-
-// DSL-style
-val smDsl = query {
-    spanMultiQuery {
-        match { rangeQuery("publish_date", gte = "2023-01-01") }
-        boost = 2.0f
-        _name = "dsl-range-span"
-    }
-}
-```
-
-Note: Only multi-term queries are allowed for `match` (prefix|wildcard|regexp|fuzzy|range). Others are ignored (no-op).
-
-See tests: [SpanMultiQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanMultiQueryTest.kt)
-### Array DSL (queries[ ... ])
-Use array-style builders inside clause blocks to add multiple queries without wrapping with `query { ... }`.
-
-```kotlin
-boolQuery {
-  mustQuery {
-    queries[
-      { termQuery { field = "tags"; value = "kotlin" } },
-      { combinedFields(query = "john smith", fields = listOf("first_name","last_name")) },
-      { rangeQuery { field = "age"; gte = 20; lt = 30 } }
-    ]
-  }
-}
-```
-
-Notes:
-- Accepts both builder lambdas and prebuilt `Query?` objects; invalid inputs are omitted.
-- Prefer builder lambdas for clarity and consistent omission semantics.
+## License
+Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,62 @@ JSON
 
 See tests: [SimpleQueryStringQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SimpleQueryStringQueryTest.kt)
 
+### More Like This
+Find documents similar to given texts and/or documents. Requires at least one `like` item. Inputs that are null/blank are omitted; an empty `like` set results in omission.
+
+```kotlin
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+
+// Text-based
+val q1 = query {
+  mlt {
+    like { text("kotlin coroutine", "typed dsl") }
+    fields("title", "body")
+    analyzer = "standard"
+    minTermFreq = 1
+    maxQueryTerms = 25
+    minimumShouldMatch = "30%"
+    stopWords("a", "the")
+    boost = 1.1f
+    _name = "mlt_text"
+  }
+}
+
+// Mixed like/unlike (documents and texts)
+val q2 = query {
+  mlt {
+    like { doc("articles", "1"); doc("articles", "2") }
+    unlike { text("legacy") }
+    fields("title")
+  }
+}
+
+// In bool with omission behavior
+val q3 = query {
+  boolQuery {
+    mustQuery {
+      moreLikeThis { like { doc("articles", "1") }; fields("title") }
+      moreLikeThis { /* no like → omitted */ }
+    }
+  }
+}
+```
+
+JSON
+```json
+{ "query": { "more_like_this": {
+  "fields": ["title","body"],
+  "like": ["kotlin coroutine", "typed dsl"],
+  "min_term_freq": 1,
+  "max_query_terms": 25,
+  "minimum_should_match": "30%",
+  "stop_words": ["a","the"],
+  "boost": 1.1
+} } }
+```
+
+See tests: [MoreLikeThisQueryTest.kt](src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MoreLikeThisQueryTest.kt)
+
 ### Span Queries
 Elasticsearch span queries enable position-aware text matching. This library provides DSL support for span queries with both function-style and DSL-style syntax.
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Type-safe Kotlin DSL for composing Elasticsearch queries. Builders omit null or 
 ## Highlights
 - **Fluent Kotlin API** – Prefer Kotlin builders over brittle JSON strings.
 - **Safe omission** – Invalid or empty values get dropped automatically.
-- **Rich coverage** – Full-text, term-level, span, compound, and specialized queries (percolate, KNN, script, script_score, wrapper, pinned, rank_feature, distance_feature).
+- **Rich coverage** – Full-text, term-level, span, compound, and specialized queries (percolate, KNN, script, script_score, wrapper, pinned, rule, rank_feature, distance_feature).
 - **Composable helpers** – `SubQueryBuilders` utilities let you stack clauses without repetitive `query { ... }` blocks.
 - **Battle-tested** – Kotest + JUnit 5 specs mirror the production package layout.
 
@@ -111,9 +111,23 @@ query {
         }
     }
 }
+
+// Rule query ties rulesets to an organic fallback with match criteria
+query {
+    ruleQueryDsl {
+        rulesetIds("featured")
+        organic {
+            matchQuery {
+                field = "status"
+                query = "active"
+            }
+        }
+        matchCriteria(mapOf("channel" to "web"))
+    }
+}
 ```
 
-Other specialized builders include `knnQuery`, `percolateQuery`, `rankFeatureQuery`, `distanceFeatureQuery`, and span integrations. Each has focused specs in `src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized`.
+Other specialized builders include `knnQuery`, `percolateQuery`, `rankFeatureQuery`, and `distanceFeatureQuery`, plus span integrations. Each has focused specs in `src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized`.
 
 ## Testing & Quality
 - Run targeted suites via Gradle’s `--tests` flag when iterating.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Type-safe Kotlin DSL for composing Elasticsearch queries. Builders omit null or 
 ## Highlights
 - **Fluent Kotlin API** – Prefer Kotlin builders over brittle JSON strings.
 - **Safe omission** – Invalid or empty values get dropped automatically.
-- **Rich coverage** – Full-text, term-level, span, compound, and specialized queries (percolate, KNN, script, script_score, wrapper, pinned, rule, rank_feature, distance_feature).
+- **Rich coverage** – Full-text, term-level, span, compound, and specialized queries (percolate, KNN, script, script_score, wrapper, pinned, rule, weighted_tokens, rank_feature, distance_feature).
 - **Composable helpers** – `SubQueryBuilders` utilities let you stack clauses without repetitive `query { ... }` blocks.
 - **Battle-tested** – Kotest + JUnit 5 specs mirror the production package layout.
 
@@ -123,6 +123,21 @@ query {
             }
         }
         matchCriteria(mapOf("channel" to "web"))
+    }
+}
+
+// Weighted tokens query describing weighted semantic tokens for a field
+query {
+    weightedTokensQuery {
+        field = "title.embedding"
+        tokens(
+            "kotlin" to 1.0,
+            "dsl" to 0.7
+        )
+        pruningConfig {
+            tokensFreqRatioThreshold = 3
+            tokensWeightThreshold = 0.2f
+        }
     }
 }
 ```

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -10,6 +10,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.ZeroTermsQuery
 import co.elastic.clients.elasticsearch._types.query_dsl.Operator
 import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType
 import co.elastic.clients.elasticsearch._types.query_dsl.SimpleQueryStringFlag
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized.*
 
 /**
  * 여러 clause 확장함수에서 재사용하는 Query 수집기.
@@ -326,5 +327,10 @@ class SubQueryBuilders {
                 this.mlt(fn)
             }
         )
+    }
+
+    // percolate helper
+    fun percolateQuery(fn: PercolateQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.percolateQuery(fn) })
     }
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -338,4 +338,9 @@ class SubQueryBuilders {
     fun knnQuery(fn: KnnQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.knnQuery(fn) })
     }
+
+    // rank_feature helper
+    fun rankFeatureQuery(fn: RankFeatureQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.rankFeatureQuery(fn) })
+    }
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -349,6 +349,11 @@ class SubQueryBuilders {
         addQuery(queryOrNull { this.pinnedQuery(fn) })
     }
 
+    // rule helper
+    fun ruleQuery(fn: RuleQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.ruleQueryDsl(fn) })
+    }
+
     // percolate helper
     fun percolateQuery(fn: PercolateQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.percolateQuery(fn) })

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -339,6 +339,11 @@ class SubQueryBuilders {
         addQuery(queryOrNull { this.scriptScoreQuery(fn) })
     }
 
+    // wrapper helper
+    fun wrapperQuery(fn: WrapperQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.wrapperQuery(fn) })
+    }
+
     // percolate helper
     fun percolateQuery(fn: PercolateQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.percolateQuery(fn) })

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -344,6 +344,11 @@ class SubQueryBuilders {
         addQuery(queryOrNull { this.wrapperQuery(fn) })
     }
 
+    // pinned helper
+    fun pinnedQuery(fn: PinnedQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.pinnedQuery(fn) })
+    }
+
     // percolate helper
     fun percolateQuery(fn: PercolateQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.percolateQuery(fn) })

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -333,4 +333,9 @@ class SubQueryBuilders {
     fun percolateQuery(fn: PercolateQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.percolateQuery(fn) })
     }
+
+    // knn helper
+    fun knnQuery(fn: KnnQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.knnQuery(fn) })
+    }
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -354,6 +354,11 @@ class SubQueryBuilders {
         addQuery(queryOrNull { this.ruleQueryDsl(fn) })
     }
 
+    // weighted_tokens helper
+    fun weightedTokensQuery(fn: WeightedTokensQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.weightedTokensQuery(fn) })
+    }
+
     // percolate helper
     fun percolateQuery(fn: PercolateQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.percolateQuery(fn) })

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -318,4 +318,13 @@ class SubQueryBuilders {
             }
         )
     }
+
+    // more_like_this helper
+    fun moreLikeThis(fn: MoreLikeThisDsl.() -> Unit) {
+        addQuery(
+            queryOrNull {
+                this.mlt(fn)
+            }
+        )
+    }
 }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -329,6 +329,11 @@ class SubQueryBuilders {
         )
     }
 
+    // script helper
+    fun scriptQuery(fn: ScriptQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.scriptQuery(fn) })
+    }
+
     // percolate helper
     fun percolateQuery(fn: PercolateQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.percolateQuery(fn) })

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -334,6 +334,11 @@ class SubQueryBuilders {
         addQuery(queryOrNull { this.scriptQuery(fn) })
     }
 
+    // script_score helper
+    fun scriptScoreQuery(fn: ScriptScoreQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.scriptScoreQuery(fn) })
+    }
+
     // percolate helper
     fun percolateQuery(fn: PercolateQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.percolateQuery(fn) })

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQuery.kt
@@ -27,7 +27,8 @@ class ConstantScoreQueryDsl {
             }
             else -> Query.of { q ->
                 q.bool { b ->
-                    filterQueries.forEach { b.must(it) }
+                    // 여러 필터는 의도에 맞게 filter 절로 묶는다
+                    filterQueries.forEach { b.filter(it) }
                     b
                 }
             }

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/IntervalsDsl.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/IntervalsDsl.kt
@@ -6,6 +6,7 @@ import co.elastic.clients.util.ObjectBuilder
 /** DSL for building Elasticsearch intervals queries in builder style. */
 class IntervalsRuleDsl {
     internal val intervals = mutableListOf<co.elastic.clients.elasticsearch._types.query_dsl.Intervals>()
+    internal val setters = mutableListOf<(co.elastic.clients.elasticsearch._types.query_dsl.IntervalsQuery.Builder) -> Unit>()
     internal var isAllOf = false
     internal var isAnyOf = false
     internal var maxGaps: Int? = null
@@ -14,6 +15,7 @@ class IntervalsRuleDsl {
     fun allOf(maxGaps: Int? = null, ordered: Boolean? = null, fn: IntervalsCollectionDsl.() -> Unit) {
         val dsl = IntervalsCollectionDsl().apply(fn)
         intervals.addAll(dsl.intervals)
+        setters.addAll(dsl.setters)
         this.isAllOf = true
         this.maxGaps = maxGaps
         this.ordered = ordered
@@ -22,6 +24,7 @@ class IntervalsRuleDsl {
     fun anyOf(fn: IntervalsCollectionDsl.() -> Unit) {
         val dsl = IntervalsCollectionDsl().apply(fn)
         intervals.addAll(dsl.intervals)
+        setters.addAll(dsl.setters)
         this.isAnyOf = true
     }
 
@@ -37,6 +40,16 @@ class IntervalsRuleDsl {
             match
         }
         intervals.add(intervalBuilder.build())
+        setters.add { iv ->
+            iv.match { mb ->
+                mb.query(query)
+                maxGaps?.let { mg -> mb.maxGaps(mg) }
+                ordered?.let { ord -> mb.ordered(ord) }
+                analyzer?.let { a -> mb.analyzer(a) }
+                useField?.let { uf -> mb.useField(uf) }
+                mb
+            }
+        }
     }
 
     fun prefix(prefix: String, analyzer: String? = null, useField: String? = null) {
@@ -49,6 +62,14 @@ class IntervalsRuleDsl {
             prefixRule
         }
         intervals.add(intervalBuilder.build())
+        setters.add { iv ->
+            iv.prefix { pb ->
+                pb.prefix(prefix)
+                analyzer?.let { a -> pb.analyzer(a) }
+                useField?.let { uf -> pb.useField(uf) }
+                pb
+            }
+        }
     }
 
     fun wildcard(pattern: String, analyzer: String? = null, useField: String? = null) {
@@ -61,6 +82,14 @@ class IntervalsRuleDsl {
             wildcard
         }
         intervals.add(intervalBuilder.build())
+        setters.add { iv ->
+            iv.wildcard { wb ->
+                wb.pattern(pattern)
+                analyzer?.let { a -> wb.analyzer(a) }
+                useField?.let { uf -> wb.useField(uf) }
+                wb
+            }
+        }
     }
 
     fun fuzzy(term: String, prefixLength: Int? = null, transpositions: Boolean? = null, fuzziness: String? = null, analyzer: String? = null, useField: String? = null) {
@@ -76,11 +105,23 @@ class IntervalsRuleDsl {
             fuzzy
         }
         intervals.add(intervalBuilder.build())
+        setters.add { iv ->
+            iv.fuzzy { fb ->
+                fb.term(term)
+                prefixLength?.let { pl -> fb.prefixLength(pl) }
+                transpositions?.let { tr -> fb.transpositions(tr) }
+                fuzziness?.let { fu -> fb.fuzziness(fu) }
+                analyzer?.let { a -> fb.analyzer(a) }
+                useField?.let { uf -> fb.useField(uf) }
+                fb
+            }
+        }
     }
 }
 
 class IntervalsCollectionDsl {
     internal val intervals = mutableListOf<co.elastic.clients.elasticsearch._types.query_dsl.Intervals>()
+    internal val setters = mutableListOf<(co.elastic.clients.elasticsearch._types.query_dsl.IntervalsQuery.Builder) -> Unit>()
 
     fun match(query: String, maxGaps: Int? = null, ordered: Boolean? = null, analyzer: String? = null, useField: String? = null) {
         if (query.isBlank()) return
@@ -94,6 +135,16 @@ class IntervalsCollectionDsl {
             match
         }
         intervals.add(intervalBuilder.build())
+        setters.add { iv ->
+            iv.match { mb ->
+                mb.query(query)
+                maxGaps?.let { mg -> mb.maxGaps(mg) }
+                ordered?.let { ord -> mb.ordered(ord) }
+                analyzer?.let { a -> mb.analyzer(a) }
+                useField?.let { uf -> mb.useField(uf) }
+                mb
+            }
+        }
     }
 
     fun prefix(prefix: String, analyzer: String? = null, useField: String? = null) {
@@ -106,6 +157,14 @@ class IntervalsCollectionDsl {
             prefixRule
         }
         intervals.add(intervalBuilder.build())
+        setters.add { iv ->
+            iv.prefix { pb ->
+                pb.prefix(prefix)
+                analyzer?.let { a -> pb.analyzer(a) }
+                useField?.let { uf -> pb.useField(uf) }
+                pb
+            }
+        }
     }
 
     fun wildcard(pattern: String, analyzer: String? = null, useField: String? = null) {
@@ -118,6 +177,14 @@ class IntervalsCollectionDsl {
             wildcard
         }
         intervals.add(intervalBuilder.build())
+        setters.add { iv ->
+            iv.wildcard { wb ->
+                wb.pattern(pattern)
+                analyzer?.let { a -> wb.analyzer(a) }
+                useField?.let { uf -> wb.useField(uf) }
+                wb
+            }
+        }
     }
 
     fun fuzzy(term: String, prefixLength: Int? = null, transpositions: Boolean? = null, fuzziness: String? = null, analyzer: String? = null, useField: String? = null) {
@@ -133,6 +200,17 @@ class IntervalsCollectionDsl {
             fuzzy
         }
         intervals.add(intervalBuilder.build())
+        setters.add { iv ->
+            iv.fuzzy { fb ->
+                fb.term(term)
+                prefixLength?.let { pl -> fb.prefixLength(pl) }
+                transpositions?.let { tr -> fb.transpositions(tr) }
+                fuzziness?.let { fu -> fb.fuzziness(fu) }
+                analyzer?.let { a -> fb.analyzer(a) }
+                useField?.let { uf -> fb.useField(uf) }
+                fb
+            }
+        }
     }
 }
 
@@ -155,17 +233,13 @@ fun Query.Builder.intervals(field: String, boost: Float? = null, _name: String? 
                 anyOf
             }
             dsl.intervals.size == 1 -> {
-                // 단일 규칙은 any_of 래핑 없이 직접 매핑한다
-                val single = dsl.intervals.first()
-                var applied = false
-                // 가능한 variant들을 직접 설정 (클라이언트의 variant getter를 사용)
-                // match/prefix/wildcard/fuzzy 중 하나만 설정되어 있음
-                single.match()?.let { m -> iv.match(m); applied = true }
-                single.prefix()?.let { p -> iv.prefix(p); applied = true }
-                single.wildcard()?.let { w -> iv.wildcard(w); applied = true }
-                single.fuzzy()?.let { f -> iv.fuzzy(f); applied = true }
-                if (!applied) {
-                    // 혹시 위 매핑이 불가능한 클라이언트 버전이면 any_of로 폴백
+                // 단일 규칙은 any_of 래핑 없이 직접 매핑한다 (사전에 저장한 setter 사용)
+                val setter = dsl.setters.firstOrNull()
+                if (setter != null) {
+                    setter(iv)
+                } else {
+                    // 폴백: any_of로 그대로 직렬화
+                    val single = dsl.intervals.first()
                     iv.anyOf { any -> any.intervals(single); any }
                 }
                 iv

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MoreLikeThisQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MoreLikeThisQuery.kt
@@ -1,0 +1,145 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Like
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.util.ObjectBuilder
+
+/**
+ * more_like_this 쿼리 DSL 빌더
+ * - like 텍스트/문서를 기준으로 유사 문서를 검색
+ * - like 항목이 비면 생성하지 않음 (생략)
+ */
+fun Query.Builder.moreLikeThis(
+    likeTexts: List<String> = emptyList(),
+    likeDocs: List<Pair<String, String>> = emptyList(), // (index, id)
+    unlikeTexts: List<String> = emptyList(),
+    unlikeDocs: List<Pair<String, String>> = emptyList(),
+    fields: List<String> = emptyList(),
+    analyzer: String? = null,
+    minimumShouldMatch: String? = null,
+    minTermFreq: Int? = null,
+    maxQueryTerms: Int? = null,
+    minDocFreq: Int? = null,
+    maxDocFreq: Int? = null,
+    minWordLength: Int? = null,
+    maxWordLength: Int? = null,
+    stopWords: List<String> = emptyList(),
+    boost: Float? = null,
+    _name: String? = null
+): ObjectBuilder<Query> {
+    // Build Like/Unlike lists
+    val likeItems = mutableListOf<Like>()
+    likeItems.addAll(likeTexts.filter { it.isNotBlank() }.map { t -> Like.of { it.text(t) } })
+    likeItems.addAll(
+        likeDocs
+            .filter { it.first.isNotBlank() && it.second.isNotBlank() }
+            .map { (index, id) ->
+                Like.of { l -> l.document { d -> d.index(index).id(id) } }
+            }
+    )
+
+    if (likeItems.isEmpty()) return this
+
+    val unlikeItems = mutableListOf<Like>()
+    unlikeItems.addAll(unlikeTexts.filter { it.isNotBlank() }.map { t -> Like.of { it.text(t) } })
+    unlikeItems.addAll(
+        unlikeDocs
+            .filter { it.first.isNotBlank() && it.second.isNotBlank() }
+            .map { (index, id) ->
+                Like.of { l -> l.document { d -> d.index(index).id(id) } }
+            }
+    )
+
+    return this.moreLikeThis { mlt ->
+        likeItems.forEach { mlt.like(it) }
+        unlikeItems.forEach { mlt.unlike(it) }
+        if (fields.isNotEmpty()) mlt.fields(fields)
+        analyzer?.let { mlt.analyzer(it) }
+        minimumShouldMatch?.let { mlt.minimumShouldMatch(it) }
+        minTermFreq?.let { mlt.minTermFreq(it) }
+        maxQueryTerms?.let { mlt.maxQueryTerms(it) }
+        minDocFreq?.let { mlt.minDocFreq(it) }
+        maxDocFreq?.let { mlt.maxDocFreq(it) }
+        minWordLength?.let { mlt.minWordLength(it) }
+        maxWordLength?.let { mlt.maxWordLength(it) }
+        if (stopWords.isNotEmpty()) mlt.stopWords(stopWords)
+        boost?.let { mlt.boost(it) }
+        _name?.let { mlt.queryName(it) }
+        mlt
+    }
+}
+
+// --- Builder-style DSL overload (preferred) ---
+class MoreLikeThisDsl {
+    internal val likeItems = mutableListOf<Like>()
+    internal val unlikeItems = mutableListOf<Like>()
+    internal val fieldsList = mutableListOf<String>()
+    internal val stopWordsList = mutableListOf<String>()
+
+    var analyzer: String? = null
+    var minimumShouldMatch: String? = null
+    var minTermFreq: Int? = null
+    var maxQueryTerms: Int? = null
+    var minDocFreq: Int? = null
+    var maxDocFreq: Int? = null
+    var minWordLength: Int? = null
+    var maxWordLength: Int? = null
+    var boost: Float? = null
+    var _name: String? = null
+
+    fun fields(vararg fields: String) {
+        fieldsList.addAll(fields.filter { it.isNotBlank() })
+    }
+
+    fun stopWords(vararg words: String) {
+        stopWordsList.addAll(words.filter { it.isNotBlank() })
+    }
+
+    fun like(fn: LikeCollector.() -> Unit) {
+        val c = LikeCollector().apply(fn)
+        likeItems.addAll(c.items)
+    }
+
+    fun unlike(fn: LikeCollector.() -> Unit) {
+        val c = LikeCollector().apply(fn)
+        unlikeItems.addAll(c.items)
+    }
+}
+
+class LikeCollector {
+    internal val items = mutableListOf<Like>()
+
+    fun text(vararg texts: String) {
+        texts.filter { it.isNotBlank() }
+            .map { t -> Like.of { it.text(t) } }
+            .let { items.addAll(it) }
+    }
+
+    fun doc(index: String, id: String) {
+        if (index.isBlank() || id.isBlank()) return
+        items.add(Like.of { l -> l.document { d -> d.index(index).id(id) } })
+    }
+}
+
+fun Query.Builder.mlt(fn: MoreLikeThisDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = MoreLikeThisDsl().apply(fn)
+    if (dsl.likeItems.isEmpty()) return this
+
+    return this.moreLikeThis { mlt ->
+        dsl.likeItems.forEach { mlt.like(it) }
+        dsl.unlikeItems.forEach { mlt.unlike(it) }
+        if (dsl.fieldsList.isNotEmpty()) mlt.fields(dsl.fieldsList)
+        dsl.analyzer?.let { mlt.analyzer(it) }
+        dsl.minimumShouldMatch?.let { mlt.minimumShouldMatch(it) }
+        dsl.minTermFreq?.let { mlt.minTermFreq(it) }
+        dsl.maxQueryTerms?.let { mlt.maxQueryTerms(it) }
+        dsl.minDocFreq?.let { mlt.minDocFreq(it) }
+        dsl.maxDocFreq?.let { mlt.maxDocFreq(it) }
+        dsl.minWordLength?.let { mlt.minWordLength(it) }
+        dsl.maxWordLength?.let { mlt.maxWordLength(it) }
+        if (dsl.stopWordsList.isNotEmpty()) mlt.stopWords(dsl.stopWordsList)
+        dsl.boost?.let { mlt.boost(it) }
+        dsl._name?.let { mlt.queryName(it) }
+        mlt
+    }
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/KnnQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/KnnQuery.kt
@@ -1,0 +1,73 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import co.elastic.clients.util.ObjectBuilder
+
+class KnnQueryDsl {
+    var field: String? = null
+    var queryVector: List<Float?>? = null
+    var k: Int? = null
+    var numCandidates: Int? = null
+
+    private val filterQueries = SubQueryBuilders()
+
+    fun filter(fn: SubQueryBuilders.() -> Any?) {
+        val sub = SubQueryBuilders()
+        val res = sub.fn()
+        if (res is Query) sub.addQuery(res)
+        filterQueries.addAll(sub)
+    }
+
+    internal fun buildFilterQuery(): Query? {
+        return when (filterQueries.size()) {
+            0 -> null
+            1 -> {
+                var result: Query? = null
+                filterQueries.forEach { result = it }
+                result
+            }
+            else -> Query.of { q ->
+                q.bool { b ->
+                    // filter semantics for multiple filters
+                    filterQueries.forEach { b.filter(it) }
+                    b
+                }
+            }
+        }
+    }
+}
+
+fun Query.Builder.knnQuery(fn: KnnQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = KnnQueryDsl().apply(fn)
+    val field = dsl.field?.takeIf { it.isNotBlank() } ?: return this
+    val vector = dsl.queryVector
+        ?.takeIf { it.isNotEmpty() && it.all { value -> value != null } }
+        ?.map { it!! }
+        ?: return this
+    val k = dsl.k?.let { provided ->
+        provided.takeIf { it > 0 } ?: return this
+    }
+    val numCandidates = dsl.numCandidates?.takeIf { it > 0 } ?: return this
+
+    return this.knn { kq ->
+        kq.field(field)
+        kq.queryVector(vector)
+        fun trySetInt(name: String, value: Int) {
+            listOfNotNull(Int::class.javaPrimitiveType, Int::class.javaObjectType).forEach { type ->
+                try {
+                    val method = kq.javaClass.getMethod(name, type)
+                    method.invoke(kq, value)
+                    return
+                } catch (_: Exception) {
+                    // try next signature (8.14에는 k 세터가 없어 무시)
+                }
+            }
+        }
+        k?.let { trySetInt("k", it) }
+        kq.numCandidates(numCandidates)
+        dsl.buildFilterQuery()?.let { fq -> kq.filter(fq) }
+        kq
+    }
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/PercolateQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/PercolateQuery.kt
@@ -1,0 +1,50 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.json.JsonData
+import co.elastic.clients.util.ObjectBuilder
+
+class PercolateQueryDsl {
+    var field: String? = null
+    var document: Map<String, Any?>? = null
+    var documents: List<Map<String, Any?>> = emptyList()
+    var index: String? = null
+    var id: String? = null
+    var routing: String? = null
+    var preference: String? = null
+    var boost: Float? = null
+    var _name: String? = null
+}
+
+fun Query.Builder.percolateQuery(fn: PercolateQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = PercolateQueryDsl().apply(fn)
+    val field = dsl.field?.takeIf { it.isNotBlank() } ?: return this
+
+    // Determine input source: single document, multiple documents, or index/id
+    val singleDoc = dsl.document?.filterKeys { it.isNotBlank() }?.takeIf { it.isNotEmpty() }
+    val docs = dsl.documents.mapNotNull { m -> m.filterKeys { it.isNotBlank() }.takeIf { it.isNotEmpty() } }
+    val hasDocs = singleDoc != null || docs.isNotEmpty()
+    val hasIndexId = !dsl.index.isNullOrBlank() && !dsl.id.isNullOrBlank()
+
+    if (!hasDocs && !hasIndexId) return this
+
+    return this.percolate { p ->
+        p.field(field)
+        if (singleDoc != null) {
+            p.document(JsonData.of(singleDoc))
+        }
+        if (docs.isNotEmpty()) {
+            p.documents(docs.map { JsonData.of(it) })
+        }
+        if (hasIndexId) {
+            p.index(dsl.index)
+            p.id(dsl.id)
+            dsl.routing?.takeIf { it.isNotBlank() }?.let { p.routing(it) }
+            dsl.preference?.takeIf { it.isNotBlank() }?.let { p.preference(it) }
+        }
+        dsl.boost?.let { p.boost(it) }
+        dsl._name?.let { p.queryName(it) }
+        p
+    }
+}
+

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/PinnedQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/PinnedQuery.kt
@@ -1,0 +1,52 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.util.ObjectBuilder
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+
+class PinnedQueryDsl {
+    var boost: Float? = null
+    var _name: String? = null
+    var organic: Query? = null
+
+    private val idBacking = mutableListOf<String>()
+
+    var ids: List<String?>?
+        get() = idBacking.toList()
+        set(value) {
+            idBacking.clear()
+            value?.forEach { addId(it) }
+        }
+
+    fun ids(vararg value: String?) {
+        value.forEach { addId(it) }
+    }
+
+    fun addId(id: String?) {
+        val trimmed = id?.trim()
+        if (!trimmed.isNullOrEmpty()) {
+            idBacking.add(trimmed)
+        }
+    }
+
+    fun organic(fn: Query.Builder.() -> Unit) {
+        organic = queryOrNull(fn)
+    }
+
+    internal fun resolvedIds(): List<String> = idBacking.filter { it.isNotEmpty() }
+}
+
+fun Query.Builder.pinnedQuery(fn: PinnedQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = PinnedQueryDsl().apply(fn)
+    val ids = dsl.resolvedIds()
+    val organic = dsl.organic ?: return this
+    if (ids.isEmpty()) return this
+
+    return this.pinned { pinned ->
+        pinned.ids(ids)
+        pinned.organic(organic)
+        dsl.boost?.let { pinned.boost(it) }
+        dsl._name?.let { pinned.queryName(it) }
+        pinned
+    }
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/RankFeatureQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/RankFeatureQuery.kt
@@ -1,0 +1,101 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.query_dsl.RankFeatureQuery
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.RankFeatureFunctionLinear
+import co.elastic.clients.util.ObjectBuilder
+
+class RankFeatureQueryDsl {
+    var field: String? = null
+    var boost: Float? = null
+    var _name: String? = null
+
+    private var functionConfig: RankFeatureFunctionConfig? = null
+
+    fun saturation(fn: RankFeatureSaturationDsl.() -> Unit = {}) {
+        functionConfig = RankFeatureFunctionConfig.Saturation(RankFeatureSaturationDsl().apply(fn))
+    }
+
+    fun logarithm(fn: RankFeatureLogarithmDsl.() -> Unit) {
+        functionConfig = RankFeatureFunctionConfig.Logarithm(RankFeatureLogarithmDsl().apply(fn))
+    }
+
+    fun linear() {
+        functionConfig = RankFeatureFunctionConfig.Linear
+    }
+
+    fun sigmoid(fn: RankFeatureSigmoidDsl.() -> Unit) {
+        functionConfig = RankFeatureFunctionConfig.Sigmoid(RankFeatureSigmoidDsl().apply(fn))
+    }
+
+    internal fun buildFunctionApplier(): ((RankFeatureQuery.Builder) -> Unit)? {
+        return when (val config = functionConfig) {
+            null -> { _: RankFeatureQuery.Builder -> }
+            RankFeatureFunctionConfig.Linear -> { builder ->
+                builder.linear(RankFeatureFunctionLinear._INSTANCE)
+            }
+            is RankFeatureFunctionConfig.Saturation -> {
+                { builder ->
+                    builder.saturation { sat ->
+                        config.dsl.pivot?.let { sat.pivot(it) }
+                        sat
+                    }
+                }
+            }
+            is RankFeatureFunctionConfig.Logarithm -> {
+                val scalingFactor = config.dsl.scalingFactor ?: return null
+                { builder ->
+                    builder.log { log ->
+                        log.scalingFactor(scalingFactor)
+                        log
+                    }
+                }
+            }
+            is RankFeatureFunctionConfig.Sigmoid -> {
+                val pivot = config.dsl.pivot ?: return null
+                val exponent = config.dsl.exponent ?: return null
+                { builder ->
+                    builder.sigmoid { sig ->
+                        sig.pivot(pivot)
+                        sig.exponent(exponent)
+                        sig
+                    }
+                }
+            }
+        }
+    }
+
+    private sealed interface RankFeatureFunctionConfig {
+        data class Saturation(val dsl: RankFeatureSaturationDsl) : RankFeatureFunctionConfig
+        data class Logarithm(val dsl: RankFeatureLogarithmDsl) : RankFeatureFunctionConfig
+        data class Sigmoid(val dsl: RankFeatureSigmoidDsl) : RankFeatureFunctionConfig
+        data object Linear : RankFeatureFunctionConfig
+    }
+}
+
+class RankFeatureSaturationDsl {
+    var pivot: Float? = null
+}
+
+class RankFeatureLogarithmDsl {
+    var scalingFactor: Float? = null
+}
+
+class RankFeatureSigmoidDsl {
+    var pivot: Float? = null
+    var exponent: Float? = null
+}
+
+fun Query.Builder.rankFeatureQuery(fn: RankFeatureQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = RankFeatureQueryDsl().apply(fn)
+    val field = dsl.field?.takeIf { it.isNotBlank() } ?: return this
+    val functionApplier = dsl.buildFunctionApplier() ?: return this
+
+    return this.rankFeature { rf ->
+        rf.field(field)
+        functionApplier(rf)
+        dsl.boost?.let { rf.boost(it) }
+        dsl._name?.let { rf.queryName(it) }
+        rf
+    }
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/RuleQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/RuleQuery.kt
@@ -1,0 +1,78 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.RuleQuery
+import co.elastic.clients.json.JsonData
+import co.elastic.clients.util.ObjectBuilder
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+
+class RuleQueryDsl {
+    var boost: Float? = null
+    var _name: String? = null
+    var organic: Query? = null
+
+    private var rulesetId: String? = null
+    private var matchCriteria: JsonData? = null
+
+    fun rulesetId(id: String?) {
+        val trimmed = id?.trim()
+        rulesetId = trimmed?.takeIf { it.isNotEmpty() }
+    }
+
+    fun rulesetIds(vararg ids: String?) {
+        rulesetId(ids.firstOrNull { !it.isNullOrBlank() })
+    }
+
+    fun rulesetIds(ids: Iterable<String?>) {
+        rulesetId(ids.firstOrNull { !it.isNullOrBlank() })
+    }
+
+    fun organic(fn: Query.Builder.() -> Unit) {
+        organic = queryOrNull(fn)
+    }
+
+    fun matchCriteria(value: JsonData?) {
+        matchCriteria = value
+    }
+
+    fun matchCriteria(value: Map<String, Any?>?) {
+        if (value == null) {
+            matchCriteria = null
+            return
+        }
+        val sanitized = value.filterValues { it != null }
+        if (sanitized.isEmpty()) {
+            matchCriteria = null
+            return
+        }
+        matchCriteria = JsonData.of(sanitized)
+    }
+
+    fun matchCriteria(value: Any?) {
+        matchCriteria = value?.let { JsonData.of(it) }
+    }
+
+    fun clearMatchCriteria() {
+        matchCriteria = null
+    }
+
+    internal fun resolvedRulesetId(): String? = rulesetId
+
+    internal fun resolvedMatchCriteria(): JsonData? = matchCriteria
+}
+
+fun Query.Builder.ruleQueryDsl(fn: RuleQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = RuleQueryDsl().apply(fn)
+    val rulesetId = dsl.resolvedRulesetId() ?: return this
+    val organic = dsl.organic ?: return this
+    val matchCriteria = dsl.resolvedMatchCriteria() ?: return this
+
+    return this.ruleQuery { builder: RuleQuery.Builder ->
+        builder.organic(organic)
+        builder.rulesetId(rulesetId)
+        builder.matchCriteria(matchCriteria)
+        dsl.boost?.let { builder.boost(it) }
+        dsl._name?.let { builder.queryName(it) }
+        builder
+    }
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptQuery.kt
@@ -5,13 +5,11 @@ import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.json.JsonData
 import co.elastic.clients.util.ObjectBuilder
 
-/** DSL helper for building script queries */
-class ScriptQueryDsl {
+/** 공통 스크립트 빌드 옵션을 제공하는 베이스 DSL */
+open class ScriptOptionsDsl {
     var source: String? = null
     var lang: String? = null
     var id: String? = null
-    var boost: Float? = null
-    var _name: String? = null
     var providedScript: Script? = null
 
     private val paramsBacking = linkedMapOf<String, Any?>()
@@ -105,6 +103,12 @@ class ScriptQueryDsl {
         }
         return converted.takeIf { it.isNotEmpty() }
     }
+}
+
+/** DSL helper for building script queries */
+class ScriptQueryDsl : ScriptOptionsDsl() {
+    var boost: Float? = null
+    var _name: String? = null
 }
 
 fun Query.Builder.scriptQuery(fn: ScriptQueryDsl.() -> Unit): ObjectBuilder<Query> {

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptQuery.kt
@@ -1,0 +1,120 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.Script
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.json.JsonData
+import co.elastic.clients.util.ObjectBuilder
+
+/** DSL helper for building script queries */
+class ScriptQueryDsl {
+    var source: String? = null
+    var lang: String? = null
+    var id: String? = null
+    var boost: Float? = null
+    var _name: String? = null
+    var providedScript: Script? = null
+
+    private val paramsBacking = linkedMapOf<String, Any?>()
+
+    var params: Map<String, Any?>?
+        get() = paramsBacking.takeIf { it.isNotEmpty() }?.toMap()
+        set(value) {
+            paramsBacking.clear()
+            value?.forEach { (key, rawValue) ->
+                val trimmedKey = key.trim()
+                if (trimmedKey.isEmpty() || rawValue == null) return@forEach
+                paramsBacking[trimmedKey] = rawValue
+            }
+        }
+
+    fun params(vararg entries: Pair<String, Any?>) {
+        if (entries.isEmpty()) return
+        entries.forEach { (key, rawValue) ->
+            val trimmedKey = key.trim()
+            if (trimmedKey.isEmpty()) return@forEach
+            if (rawValue == null) {
+                paramsBacking.remove(trimmedKey)
+            } else {
+                paramsBacking[trimmedKey] = rawValue
+            }
+        }
+    }
+
+    fun inline(source: String, lang: String? = null, params: Map<String, Any?>? = null) {
+        this.source = source
+        this.lang = lang
+        this.id = null
+        this.params = params
+    }
+
+    fun stored(id: String, params: Map<String, Any?>? = null) {
+        this.id = id
+        this.source = null
+        this.lang = null
+        this.params = params
+    }
+
+    fun clearParams() {
+        paramsBacking.clear()
+    }
+
+    fun script(fn: Script.Builder.() -> Unit) {
+        providedScript = Script.of { builder ->
+            builder.fn()
+            builder
+        }
+    }
+
+    internal fun buildScript(): Script? {
+        providedScript?.let { return it }
+
+        val storedId = id?.takeIf { it.isNotBlank() }
+        val inlineSource = source?.takeIf { it.isNotBlank() }
+        val params = buildParams()
+
+        return when {
+            storedId != null -> Script.of { script ->
+                script.stored { stored ->
+                    stored.id(storedId)
+                    params?.let { stored.params(it) }
+                }
+            }
+            inlineSource != null -> Script.of { script ->
+                script.inline { inline ->
+                    inline.source(inlineSource)
+                    lang?.takeIf { it.isNotBlank() }?.let { inline.lang(it) }
+                    params?.let { inline.params(it) }
+                }
+            }
+            else -> null
+        }
+    }
+
+    private fun buildParams(): Map<String, JsonData>? {
+        if (paramsBacking.isEmpty()) return null
+
+        val converted = linkedMapOf<String, JsonData>()
+        paramsBacking.forEach { (key, rawValue) ->
+            val trimmedKey = key.trim()
+            if (trimmedKey.isEmpty() || rawValue == null) return@forEach
+            val jsonValue = when (rawValue) {
+                is JsonData -> rawValue
+                else -> runCatching { JsonData.of(rawValue) }.getOrNull()
+            }
+            jsonValue?.let { converted[trimmedKey] = it }
+        }
+        return converted.takeIf { it.isNotEmpty() }
+    }
+}
+
+fun Query.Builder.scriptQuery(fn: ScriptQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = ScriptQueryDsl().apply(fn)
+    val script = dsl.buildScript() ?: return this
+
+    return this.script { sq ->
+        sq.script(script)
+        dsl.boost?.let { sq.boost(it) }
+        dsl._name?.let { sq.queryName(it) }
+        sq
+    }
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptScoreQuery.kt
@@ -1,0 +1,35 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.util.ObjectBuilder
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+
+/** DSL helper for building script_score queries */
+class ScriptScoreQueryDsl : ScriptOptionsDsl() {
+    var boost: Float? = null
+    var _name: String? = null
+    var minScore: Float? = null
+    var query: Query? = null
+
+    fun query(fn: Query.Builder.() -> Unit) {
+        query = queryOrNull(fn)
+    }
+}
+
+fun Query.Builder.scriptScoreQuery(fn: ScriptScoreQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = ScriptScoreQueryDsl().apply(fn)
+    val script = dsl.buildScript() ?: return this
+
+    val innerQuery = dsl.query ?: Query.of { q ->
+        q.matchAll { matchAll -> matchAll }
+    }
+
+    return this.scriptScore { builder ->
+        builder.query(innerQuery)
+        builder.script(script)
+        dsl.boost?.let { builder.boost(it) }
+        dsl._name?.let { builder.queryName(it) }
+        dsl.minScore?.let { builder.minScore(it) }
+        builder
+    }
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/WeightedTokensQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/WeightedTokensQuery.kt
@@ -1,0 +1,69 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.TokenPruningConfig
+import co.elastic.clients.elasticsearch._types.query_dsl.WeightedTokensQuery
+import co.elastic.clients.util.ObjectBuilder
+
+class WeightedTokensQueryDsl {
+    var field: String? = null
+    var boost: Float? = null
+    var _name: String? = null
+
+    private val tokens = linkedMapOf<String, Float>()
+    private var pruning: TokenPruningConfigDsl? = null
+
+    fun token(value: String?, weight: Number?) {
+        val key = value?.trim()
+        if (key.isNullOrEmpty() || weight == null) return
+        tokens[key] = weight.toFloat()
+    }
+
+    fun tokens(vararg entries: Pair<String?, Number?>) {
+        entries.forEach { (key, value) -> token(key, value) }
+    }
+
+    fun tokens(map: Map<String?, Number?>?) {
+        map?.forEach { (key, value) -> token(key, value) }
+    }
+
+    fun pruningConfig(fn: TokenPruningConfigDsl.() -> Unit) {
+        pruning = TokenPruningConfigDsl().apply(fn)
+    }
+
+    internal fun resolvedTokens(): Map<String, Float> = tokens.toMap()
+
+    internal fun resolvedPruning(): TokenPruningConfig? = pruning?.build()
+}
+
+class TokenPruningConfigDsl {
+    var tokensFreqRatioThreshold: Int? = null
+    var tokensWeightThreshold: Float? = null
+    var onlyScorePrunedTokens: Boolean? = null
+
+    fun build(): TokenPruningConfig? {
+        if (tokensFreqRatioThreshold == null && tokensWeightThreshold == null && onlyScorePrunedTokens == null) {
+            return null
+        }
+        return TokenPruningConfig.Builder().apply {
+            tokensFreqRatioThreshold?.let { tokensFreqRatioThreshold(it) }
+            tokensWeightThreshold?.let { tokensWeightThreshold(it) }
+            onlyScorePrunedTokens?.let { onlyScorePrunedTokens(it) }
+        }.build()
+    }
+}
+
+fun Query.Builder.weightedTokensQuery(fn: WeightedTokensQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = WeightedTokensQueryDsl().apply(fn)
+    val field = dsl.field?.takeIf { it.isNotBlank() } ?: return this
+    val tokens = dsl.resolvedTokens().takeIf { it.isNotEmpty() } ?: return this
+
+    return this.weightedTokens { builder: WeightedTokensQuery.Builder ->
+        builder.field(field)
+        builder.tokens(tokens)
+        dsl.resolvedPruning()?.let { builder.pruningConfig(it) }
+        dsl.boost?.let { builder.boost(it) }
+        dsl._name?.let { builder.queryName(it) }
+        builder
+    }
+}

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/WrapperQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/WrapperQuery.kt
@@ -1,0 +1,76 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.util.ObjectBuilder
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+class WrapperQueryDsl {
+    var boost: Float? = null
+    var _name: String? = null
+
+    private var encodedQuery: String? = null
+    private var rawPayload: ByteArray? = null
+
+    var query: String?
+        get() = encodedQuery
+        set(value) {
+            base64(value)
+        }
+
+    /**
+     * Set the wrapper query with a base64 encoded payload.
+     */
+    fun base64(value: String?) {
+        encodedQuery = value
+        if (!value.isNullOrBlank()) {
+            rawPayload = null
+        }
+    }
+
+    /**
+     * Provide raw JSON (or other encoded string) and have it base64 encoded automatically.
+     */
+    fun rawJson(json: String, charset: Charset = StandardCharsets.UTF_8) {
+        if (json.isBlank()) {
+            rawPayload = null
+            encodedQuery = null
+            return
+        }
+        rawPayload = json.toByteArray(charset)
+        encodedQuery = null
+    }
+
+    /**
+     * Provide raw bytes that will be base64 encoded.
+     */
+    fun rawBytes(bytes: ByteArray) {
+        if (bytes.isEmpty()) {
+            rawPayload = null
+            encodedQuery = null
+            return
+        }
+        rawPayload = bytes.copyOf()
+        encodedQuery = null
+    }
+
+    internal fun buildEncodedQuery(): String? {
+        rawPayload?.takeIf { it.isNotEmpty() }?.let { bytes ->
+            return Base64.getEncoder().encodeToString(bytes)
+        }
+        return encodedQuery?.takeIf { it.isNotBlank() }
+    }
+}
+
+fun Query.Builder.wrapperQuery(fn: WrapperQueryDsl.() -> Unit): ObjectBuilder<Query> {
+    val dsl = WrapperQueryDsl().apply(fn)
+    val encoded = dsl.buildEncodedQuery() ?: return this
+
+    return this.wrapper { wrapper ->
+        wrapper.query(encoded)
+        dsl.boost?.let { wrapper.boost(it) }
+        dsl._name?.let { wrapper.queryName(it) }
+        wrapper
+    }
+}

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQueryTest.kt
@@ -10,7 +10,6 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.*
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 
@@ -65,15 +64,14 @@ class ConstantScoreQueryTest : FunSpec({
     }
 
     test("필터가 비어있을 때 최상위 constant_score는 건너뛰어야 한다") {
-        shouldThrow<Exception> {
-            query {
-                constantScoreQuery {
-                    filterQuery {
-                        termQuery { field = "brand"; value = null }
-                    }
+        val q = queryOrNull {
+            constantScoreQuery {
+                filterQuery {
+                    termQuery { field = "brand"; value = null }
                 }
             }
         }
+        q shouldBe null
     }
 
     test("bool 절 내부의 constant_score는 필터가 비어있을 때 건너뛰어야 한다") {

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQueryTest.kt
@@ -110,9 +110,9 @@ class ConstantScoreQueryTest : FunSpec({
 
         val csFilter = query.bool().filter().first().constantScore().filter()
         csFilter.isBool shouldBe true
-        csFilter.bool().must().size shouldBe 2
-        csFilter.bool().must().any { it.term().field() == "brand" } shouldBe true
-        csFilter.bool().must().any { it.term().field() == "category" } shouldBe true
+        csFilter.bool().filter().size shouldBe 2
+        csFilter.bool().filter().any { it.term().field() == "brand" } shouldBe true
+        csFilter.bool().filter().any { it.term().field() == "category" } shouldBe true
     }
 
     test("constant_score 필터는 복잡한 bool 쿼리를 포함할 수 있다") {

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/IntervalsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/IntervalsQueryTest.kt
@@ -5,6 +5,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.shouldQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import io.kotest.core.spec.style.FunSpec
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
@@ -58,13 +59,13 @@ class IntervalsQueryTest : FunSpec({
     }
     
     test("필수 파라미터가 null이거나 빈 값이면 null을 반환해야 함") {
-        val query1 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals(" ") { anyOf { match("test") } } }
+        val query1 = queryOrNull { intervals(" ") { anyOf { match("test") } } }
         query1 shouldBe null
         
-        val query2 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals("content") { match("") } }
+        val query2 = queryOrNull { intervals("content") { match("") } }
         query2 shouldBe null
         
-        val query3 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals("") { anyOf { prefix("p") } } }
+        val query3 = queryOrNull { intervals("") { anyOf { prefix("p") } } }
         query3 shouldBe null
     }
     
@@ -124,7 +125,7 @@ class IntervalsQueryTest : FunSpec({
     }
     
     test("field가 빈 문자열일 때 null 반환") {
-        val query = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals(" ") { anyOf { match("test") } } }
+        val query = queryOrNull { intervals(" ") { anyOf { match("test") } } }
         query shouldBe null
     }
     
@@ -199,7 +200,7 @@ class IntervalsQueryTest : FunSpec({
     }
     
     test("복합 DSL - 빈 규칙일 때 null 반환") {
-        val query = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals("content") { /* empty */ } }
+        val query = queryOrNull { intervals("content") { /* empty */ } }
         query shouldBe null
     }
     

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/IntervalsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/IntervalsQueryTest.kt
@@ -12,18 +12,17 @@ class IntervalsQueryTest : FunSpec({
     
     test("기본 intervals match query가 생성되어야 함") {
         val query = query {
-            intervals("content") { anyOf { match("quick brown fox") } }
+            intervals("content") { match("quick brown fox") }
         }
 
         query shouldNotBe null
         query.isIntervals shouldBe true
-        // Note: With the new structure, we're using anyOf wrapper, so the actual structure is different
-        // We can verify that the query was created successfully
+        // 단일 규칙은 any_of 래핑 없이 직렬화
     }
     
     test("intervals match query에 maxGaps과 ordered 옵션이 적용되어야 함") {
         val query = query {
-            intervals("content") { anyOf { match("quick brown", maxGaps = 2, ordered = true) } }
+            intervals("content") { match("quick brown", maxGaps = 2, ordered = true) }
         }
         
         // The query should be created successfully
@@ -32,7 +31,7 @@ class IntervalsQueryTest : FunSpec({
     }
     
     test("intervals prefix query가 생성되어야 함") {
-        val query = query { intervals("content") { anyOf { prefix("qu") } } }
+        val query = query { intervals("content") { prefix("qu") } }
         
         query.isIntervals shouldBe true
         // With anyOf wrapper structure, direct access to prefix is not straightforward
@@ -40,19 +39,19 @@ class IntervalsQueryTest : FunSpec({
     }
     
     test("intervals wildcard query가 생성되어야 함") {
-        val query = query { intervals("content") { anyOf { wildcard("bro*") } } }
+        val query = query { intervals("content") { wildcard("bro*") } }
         
         query.isIntervals shouldBe true
     }
     
     test("intervals fuzzy query가 생성되어야 함") {
-        val query = query { intervals("content") { anyOf { fuzzy("fox", fuzziness = "1", prefixLength = 0, transpositions = true) } } }
+        val query = query { intervals("content") { fuzzy("fox", fuzziness = "1", prefixLength = 0, transpositions = true) } }
         
         query.isIntervals shouldBe true
     }
     
     test("boost와 _name 파라미터가 적용되어야 함") {
-        val query = query { intervals("content", boost = 2.5f, _name = "test_intervals_query") { anyOf { match("test query") } } }
+        val query = query { intervals("content", boost = 2.5f, _name = "test_intervals_query") { match("test query") } }
         
         query.isIntervals shouldBe true
         // With the new structure, boost and _name are applied to the intervals query level
@@ -62,7 +61,7 @@ class IntervalsQueryTest : FunSpec({
         val query1 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals(" ") { anyOf { match("test") } } }
         query1 shouldBe null
         
-        val query2 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals("content") { anyOf { match("") } } }
+        val query2 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals("content") { match("") } }
         query2 shouldBe null
         
         val query3 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { intervals("") { anyOf { prefix("p") } } }
@@ -72,7 +71,7 @@ class IntervalsQueryTest : FunSpec({
     test("bool 쿼리에서 사용할 수 있어야 함") {
         val query = query {
             boolQuery {
-                mustQuery { intervals("content") { anyOf { match("quick brown fox") } } }
+                mustQuery { intervals("content") { match("quick brown fox") } }
             }
         }
         
@@ -87,8 +86,8 @@ class IntervalsQueryTest : FunSpec({
             boolQuery {
                 mustQuery {
                     queries[
-                        { intervals("content") { anyOf { match("quick brown") } } },
-                        { intervals("title") { anyOf { prefix("fox") } } }
+                        { intervals("content") { match("quick brown") } },
+                        { intervals("title") { prefix("fox") } }
                     ]
                 }
             }
@@ -101,10 +100,10 @@ class IntervalsQueryTest : FunSpec({
     }
     
     test("각 query 타입이 올바르게 생성되어야 함") {
-        val matchQuery = query { intervals("content") { anyOf { match("test") } } }
-        val prefixQuery = query { intervals("content") { anyOf { prefix("test") } } }
-        val wildcardQuery = query { intervals("content") { anyOf { wildcard("test*") } } }
-        val fuzzyQuery = query { intervals("content") { anyOf { fuzzy("test") } } }
+        val matchQuery = query { intervals("content") { match("test") } }
+        val prefixQuery = query { intervals("content") { prefix("test") } }
+        val wildcardQuery = query { intervals("content") { wildcard("test*") } }
+        val fuzzyQuery = query { intervals("content") { fuzzy("test") } }
         
         matchQuery.isIntervals shouldBe true
         prefixQuery.isIntervals shouldBe true
@@ -113,13 +112,13 @@ class IntervalsQueryTest : FunSpec({
     }
     
     test("모든 파라미터가 적용된 intervals match query") {
-        val query = query { intervals("content", boost = 1.5f, _name = "test_match_query") { anyOf { match("test query", maxGaps = 2, ordered = true, analyzer = "standard", useField = "content.analyzed") } } }
+        val query = query { intervals("content", boost = 1.5f, _name = "test_match_query") { match("test query", maxGaps = 2, ordered = true, analyzer = "standard", useField = "content.analyzed") } }
         
         query.isIntervals shouldBe true
     }
     
     test("모든 파라미터가 적용된 intervals fuzzy query") {
-        val query = query { intervals("content", boost = 2.0f, _name = "test_fuzzy_query") { anyOf { fuzzy("test", prefixLength = 2, transpositions = false, fuzziness = "AUTO", analyzer = "standard", useField = "content.analyzed") } } }
+        val query = query { intervals("content", boost = 2.0f, _name = "test_fuzzy_query") { fuzzy("test", prefixLength = 2, transpositions = false, fuzziness = "AUTO", analyzer = "standard", useField = "content.analyzed") } }
         
         query.isIntervals shouldBe true
     }
@@ -175,8 +174,8 @@ class IntervalsQueryTest : FunSpec({
     }
     
     test("복합 DSL - 단일 규칙이 동작해야 함") {
-        val query1 = query { intervals("content") { anyOf { match("single match") } } }
-        val query2 = query { intervals("content") { anyOf { prefix("test") } } }
+        val query1 = query { intervals("content") { match("single match") } }
+        val query2 = query { intervals("content") { prefix("test") } }
         
         query1 shouldNotBe null
         query1.isIntervals shouldBe true

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchBoolPrefixQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchBoolPrefixQueryTest.kt
@@ -8,6 +8,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.shouldQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import io.kotest.core.spec.style.FunSpec
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
 import io.kotest.matchers.shouldBe
 
 class MatchBoolPrefixQueryTest : FunSpec({
@@ -49,8 +50,8 @@ class MatchBoolPrefixQueryTest : FunSpec({
             boolQuery {
                 mustQuery {
                     queries[
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchBoolPrefix(field = "a", query = null) },
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchBoolPrefix(field = "b", query = "") },
+                        queryOrNull { matchBoolPrefix(field = "a", query = null) },
+                        queryOrNull { matchBoolPrefix(field = "b", query = "") },
                         query { matchBoolPrefix(field = "c", query = "hello w") }
                     ]
                 }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchQueryTest.kt
@@ -161,8 +161,8 @@ class MatchQueryTest : FunSpec({
             boolQuery {
                 mustNotQuery {
                     queries[
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchQuery { field = "a"; query = null } },
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchQuery { field = "b"; query = "" } },
+                        queryOrNull { matchQuery { field = "a"; query = null } },
+                        queryOrNull { matchQuery { field = "b"; query = "" } },
                         query { matchQuery { field = "c"; query = "3333" } }
                     ]
                 }
@@ -183,8 +183,8 @@ class MatchQueryTest : FunSpec({
             boolQuery {
                 mustNotQuery {
                     queries[
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchQuery { field = "a"; query = "" } },
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchQuery { field = "b"; query = null } }
+                        queryOrNull { matchQuery { field = "a"; query = "" } },
+                        queryOrNull { matchQuery { field = "b"; query = null } }
                     ]
                 }
             }
@@ -220,8 +220,8 @@ class MatchQueryTest : FunSpec({
             boolQuery {
                 shouldQuery {
                     queries[
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchQuery { field = "a"; query = null } },
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchQuery { field = "b"; query = "" } },
+                        queryOrNull { matchQuery { field = "a"; query = null } },
+                        queryOrNull { matchQuery { field = "b"; query = "" } },
                         query { matchQuery { field = "c"; query = "3333" } }
                     ]
                 }
@@ -242,8 +242,8 @@ class MatchQueryTest : FunSpec({
             boolQuery {
                 shouldQuery {
                     queries[
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchQuery { field = "a"; query = "" } },
-                        com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { matchQuery { field = "b"; query = null } }
+                        queryOrNull { matchQuery { field = "a"; query = "" } },
+                        queryOrNull { matchQuery { field = "b"; query = null } }
                     ]
                 }
             }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MoreLikeThisQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MoreLikeThisQueryTest.kt
@@ -1,0 +1,77 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class MoreLikeThisQueryTest : FunSpec({
+
+    test("최상위 more_like_this 쿼리 생성 - text 기준") {
+        val q = query {
+            mlt {
+                like { text("kotlin coroutine", "typed dsl") }
+                fields("title", "body")
+                analyzer = "standard"
+                minTermFreq = 1
+                maxQueryTerms = 25
+                minimumShouldMatch = "30%"
+                stopWords("a", "the")
+                boost = 1.1f
+                _name = "mlt_text"
+            }
+        }
+
+        q.isMoreLikeThis shouldBe true
+        val mlt = q.moreLikeThis()
+        mlt.fields().size shouldBe 2
+        mlt.analyzer() shouldBe "standard"
+        mlt.minTermFreq() shouldBe 1
+        mlt.maxQueryTerms() shouldBe 25
+        mlt.minimumShouldMatch() shouldBe "30%"
+        mlt.stopWords().size shouldBe 2
+        mlt.boost() shouldBe 1.1f
+        mlt.queryName() shouldBe "mlt_text"
+        mlt.like().size shouldBe 2
+        // 첫 like는 텍스트여야 함
+        mlt.like()[0].text() shouldBe "kotlin coroutine"
+    }
+
+    test("문서 기반 like/unlike 혼합 및 must 절에서의 생성/생략") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    // 생성됨
+                    moreLikeThis {
+                        like { doc("articles", "1") }
+                        unlike { text("legacy") }
+                        fields("title")
+                    }
+                    // 생략됨: like이 비어있음
+                    moreLikeThis { /* no like */ }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        val must = q.bool().must()
+        must.size shouldBe 1
+        val mlt = must.first().moreLikeThis()
+        mlt.like().size shouldBe 1
+        mlt.unlike().size shouldBe 1
+        // 문서 like 검증 (index/id)
+        mlt.like().first().document().index() shouldBe "articles"
+        mlt.like().first().document().id() shouldBe "1"
+    }
+
+    test("invalid 입력은 생략되어야 함 (blank 텍스트, 잘못된 문서 참조)") {
+        val q = queryOrNull {
+            mlt {
+                like { text(" "); doc("", ""); doc("idx", "") }
+            }
+        }
+        q shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanFirstQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanFirstQueryTest.kt
@@ -3,6 +3,7 @@ package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -33,7 +34,7 @@ class SpanFirstQueryTest : FunSpec({
     }
 
     test("spanFirstQuery should return null if match is not set") {
-        val query = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull {
+        val query = queryOrNull {
             spanFirstQueryDsl {
                 end = 3
             }
@@ -42,7 +43,7 @@ class SpanFirstQueryTest : FunSpec({
     }
 
     test("spanFirstQuery should throw exception if end is not set") {
-        val q = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull {
+        val q = queryOrNull {
             spanFirstQueryDsl { match { spanTermQuery { field = "user.id"; value = "kimchy" } } }
         }
         q shouldBe null

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanMultiQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanMultiQueryTest.kt
@@ -1,6 +1,7 @@
 package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.span
 
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.rangeQuery
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
@@ -84,10 +85,10 @@ class SpanMultiQueryTest : FunSpec({
     }
 
     test("spanMultiQuery(match = null) 또는 비-멀티텀은 null 반환") {
-        val nullMatch = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { spanMultiQuery { /* no match */ } }
+        val nullMatch = queryOrNull { spanMultiQuery { /* no match */ } }
         nullMatch shouldBe null
 
-        val nonMulti = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull { spanMultiQuery { match { query { spanTermQuery { field = "f"; value = "v" } } } } }
+        val nonMulti = queryOrNull { spanMultiQuery { match { query { spanTermQuery { field = "f"; value = "v" } } } } }
         nonMulti shouldBe null
     }
 })

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanQueriesTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/span/SpanQueriesTest.kt
@@ -4,6 +4,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
 import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
 import io.kotest.core.spec.style.FunSpec
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
@@ -50,7 +51,7 @@ class SpanQueriesTest : FunSpec({
 
     test("span_containing: null 입력 시 쿼리 생략") {
         // 1. 내부 쿼리가 null을 반환하는 경우
-        val q1 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull {
+        val q1 = queryOrNull {
             spanContainingQuery {
                 little { /* none */ }
                 big { spanNearQuery { clauses[ { spanTermQuery { field = "body"; value = "x" } } ]; slop = 0 } }
@@ -59,7 +60,7 @@ class SpanQueriesTest : FunSpec({
         q1 shouldBe null
 
         // 2. 인자 자체가 null인 경우
-        val q2 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull {
+        val q2 = queryOrNull {
             spanContainingQuery {
                 little { spanTermQuery { field = "body"; value = "apple" } }
                 big { /* none */ }
@@ -70,18 +71,18 @@ class SpanQueriesTest : FunSpec({
 
     test("span_near: 잘못된 파라미터(빈 clauses, 음수 slop) 생략") {
         // clauses가 비어있거나 null만 포함
-        val invalid1 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull {
+        val invalid1 = queryOrNull {
             spanNearQuery { slop = 1 }
         }
         invalid1 shouldBe null
 
-        val invalid2 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull {
+        val invalid2 = queryOrNull {
             spanNearQuery { slop = 1; clauses[ null, null ] }
         }
         invalid2 shouldBe null
 
         // slop이 음수
-        val invalid3 = com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull {
+        val invalid3 = queryOrNull {
             spanNearQuery { slop = -1; clauses[ { spanTermQuery { field = "f"; value = "v" } } ] }
         }
         invalid3 shouldBe null

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/KnnQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/KnnQueryTest.kt
@@ -1,0 +1,91 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class KnnQueryTest : FunSpec({
+
+    test("최상위 knn 쿼리 생성 및 속성 확인") {
+        val q = query {
+            knnQuery {
+                field = "embedding"
+                queryVector = listOf(0.1f, -0.2f, 0.3f)
+                k = 5
+                numCandidates = 50
+            }
+        }
+
+        q.isKnn shouldBe true
+        val kq = q.knn()
+        kq.field() shouldBe "embedding"
+        kq.queryVector().size shouldBe 3
+        kq.numCandidates() shouldBe 50
+    }
+
+    test("8.14 클라이언트 호환: k 없이도 생성 가능") {
+        val q = query {
+            knnQuery {
+                field = "vec"
+                queryVector = listOf(0.2f, 0.3f)
+                numCandidates = 20
+            }
+        }
+
+        q.isKnn shouldBe true
+        q.knn().numCandidates() shouldBe 20
+    }
+
+    test("knn 쿼리 filter 조합 - 단일 필터") {
+        val q = query {
+            knnQuery {
+                field = "vec"
+                queryVector = listOf(0.01f, 0.02f)
+                k = 3
+                numCandidates = 20
+                filter { termQuery { field = "status"; value = "active" } }
+            }
+        }
+
+        q.isKnn shouldBe true
+        val filters = q.knn().filter()
+        filters.size shouldBe 1
+        filters.first().isTerm shouldBe true
+    }
+
+    test("knn 쿼리 filter 조합 - 다중 필터는 bool.filter로 래핑") {
+        val q = query {
+            knnQuery {
+                field = "vec"
+                queryVector = listOf(0.0f, 0.1f)
+                k = 10
+                numCandidates = 100
+                filter {
+                    termQuery { field = "category"; value = "electronics" }
+                    termQuery { field = "brand"; value = "acme" }
+                }
+            }
+        }
+
+        val filters = q.knn().filter()
+        filters.size shouldBe 1
+        val boolFilter = filters.first()
+        boolFilter.isBool shouldBe true
+        boolFilter.bool().filter().size shouldBe 2
+    }
+
+    test("유효성 검사: 필수 값이 없으면 생략") {
+        // field가 비었으면 null
+        queryOrNull { knnQuery { field = ""; queryVector = listOf(0.1f); k = 1; numCandidates = 10 } } shouldBe null
+        // queryVector가 비면 null
+        queryOrNull { knnQuery { field = "v"; queryVector = emptyList(); k = 1; numCandidates = 10 } } shouldBe null
+        // queryVector에 null 요소가 있으면 null
+        queryOrNull { knnQuery { field = "v"; queryVector = listOf(0.1f, null); k = 1; numCandidates = 10 } } shouldBe null
+        // k가 주어졌지만 유효하지 않으면 생략
+        queryOrNull { knnQuery { field = "v"; queryVector = listOf(0.1f); k = 0; numCandidates = 10 } } shouldBe null
+        // numCandidates는 필수
+        queryOrNull { knnQuery { field = "v"; queryVector = listOf(0.1f); k = 1; numCandidates = 0 } } shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/PercolateQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/PercolateQueryTest.kt
@@ -1,0 +1,89 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class PercolateQueryTest : FunSpec({
+
+    test("최상위 percolate 쿼리 - 단일 문서") {
+        val q = query {
+            percolateQuery {
+                field = "queries" // percolator type field
+                document = mapOf(
+                    "message" to "Elasticsearch percolator test",
+                    "tags" to listOf("search", "kotlin")
+                )
+                boost = 1.2f
+                _name = "perco_single"
+            }
+        }
+
+        q.isPercolate shouldBe true
+        val p = q.percolate()
+        p.field() shouldBe "queries"
+        p.boost() shouldBe 1.2f
+        p.queryName() shouldBe "perco_single"
+        // 직렬화 형태는 클라이언트 버전에 따라 다를 수 있으므로 간단 확인만 수행
+        q.toString().isNotBlank() shouldBe true
+    }
+
+    test("percolate - 다중 문서(documents) + bool.must 내 사용") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    percolateQuery {
+                        field = "queries"
+                        documents = listOf(
+                            mapOf("message" to "first"),
+                            mapOf("message" to "second", "user" to "kimchy")
+                        )
+                    }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        val must = q.bool().must()
+        must.size shouldBe 1
+        val p = must.first().percolate()
+        p.field() shouldBe "queries"
+        // 직렬화 형태는 클라이언트 버전에 따라 다를 수 있으므로 간단 확인만 수행
+        must.first().toString().isNotBlank() shouldBe true
+    }
+
+    test("percolate - 기존 문서 참조(index/id/routing)") {
+        val q = query {
+            percolateQuery {
+                field = "queries"
+                index = "docs"
+                id = "_doc_1"
+                routing = "user-1"
+            }
+        }
+
+        q.isPercolate shouldBe true
+        val p = q.percolate()
+        p.field() shouldBe "queries"
+        p.index() shouldBe "docs"
+        p.id() shouldBe "_doc_1"
+        p.routing() shouldBe "user-1"
+    }
+
+    test("유효하지 않은 입력은 생략되어야 함") {
+        // 빈 field
+        val q1 = queryOrNull { percolateQuery { field = " "; document = mapOf("a" to 1) } }
+        q1 shouldBe null
+
+        // field는 있지만 문서/참조 없음
+        val q2 = queryOrNull { percolateQuery { field = "queries" } }
+        q2 shouldBe null
+
+        // 빈 map만 전달되는 경우
+        val q3 = queryOrNull { percolateQuery { field = "queries"; document = emptyMap() } }
+        q3 shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/PinnedQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/PinnedQueryTest.kt
@@ -1,0 +1,85 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext.matchQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class PinnedQueryTest : FunSpec({
+
+    test("pinned query - builds with ids and organic query") {
+        val q = query {
+            pinnedQuery {
+                ids("1", "2 ", null, " 3")
+                organic {
+                    matchQuery {
+                        field = "title"
+                        query = "elasticsearch"
+                    }
+                }
+                boost = 1.1f
+                _name = "pinned-sample"
+            }
+        }
+
+        q.shouldNotBeNull()
+        q.isPinned shouldBe true
+        val pinned = q.pinned()
+        pinned.boost() shouldBe 1.1f
+        pinned.queryName() shouldBe "pinned-sample"
+        pinned.ids() shouldContainExactly listOf("1", "2", "3")
+        pinned.organic().isMatch shouldBe true
+        pinned.organic().match().field() shouldBe "title"
+    }
+
+    test("pinned query - usable inside bool.must helper") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    pinnedQuery {
+                        ids = listOf("a", "b")
+                        organic {
+                            matchQuery {
+                                field = "status"
+                                query = "active"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        val mustQueries = q.bool().must()
+        mustQueries.size shouldBe 1
+        val nested = mustQueries.first()
+        nested.isPinned shouldBe true
+        nested.pinned().ids() shouldContainExactly listOf("a", "b")
+    }
+
+    test("pinned query - invalid definitions are skipped") {
+        val noIds = queryOrNull {
+            pinnedQuery {
+                organic {
+                    matchQuery {
+                        field = "title"
+                        query = "search"
+                    }
+                }
+            }
+        }
+        noIds shouldBe null
+
+        val noOrganic = queryOrNull {
+            pinnedQuery {
+                ids("1", "2")
+            }
+        }
+        noOrganic shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/RankFeatureQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/RankFeatureQueryTest.kt
@@ -1,0 +1,101 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.nulls.shouldNotBeNull
+
+class RankFeatureQueryTest : FunSpec({
+
+    test("rank_feature saturation DSL builds with metadata") {
+        val q = query {
+            rankFeatureQuery {
+                field = "pagerank"
+                saturation { pivot = 2.5f }
+                boost = 1.1f
+                _name = "pagerank_rank"
+            }
+        }
+
+        q.isRankFeature shouldBe true
+        val rq = q.rankFeature()
+        rq.field() shouldBe "pagerank"
+        rq.boost() shouldBe 1.1f
+        rq.queryName() shouldBe "pagerank_rank"
+        rq.saturation()?.pivot() shouldBe 2.5f
+        rq.log() shouldBe null
+    }
+
+    test("rank_feature linear function produces empty function payload") {
+        val q = query {
+            rankFeatureQuery {
+                field = "freshness_score"
+                linear()
+            }
+        }
+
+        q.isRankFeature shouldBe true
+        val rf = q.rankFeature()
+        rf.linear().shouldNotBeNull()
+        rf.saturation() shouldBe null
+        rf.log() shouldBe null
+        rf.sigmoid() shouldBe null
+    }
+
+    test("rank_feature logarithm requires scaling factor") {
+        queryOrNull {
+            rankFeatureQuery {
+                field = "pagerank"
+                logarithm { }
+            }
+        } shouldBe null
+
+        val q = query {
+            rankFeatureQuery {
+                field = "pagerank"
+                logarithm { scalingFactor = 3.5f }
+            }
+        }
+
+        q.rankFeature().log()?.scalingFactor() shouldBe 3.5f
+    }
+
+    test("rank_feature sigmoid requires pivot and exponent") {
+        queryOrNull {
+            rankFeatureQuery {
+                field = "signal"
+                sigmoid { pivot = 3f }
+            }
+        } shouldBe null
+
+        val q = query {
+            rankFeatureQuery {
+                field = "signal"
+                sigmoid {
+                    pivot = 3f
+                    exponent = 1.2f
+                }
+            }
+        }
+
+        q.rankFeature().sigmoid()?.pivot() shouldBe 3f
+        q.rankFeature().sigmoid()?.exponent() shouldBe 1.2f
+    }
+
+    test("rank_feature without function yields minimal query") {
+        val q = query {
+            rankFeatureQuery {
+                field = "pagerank"
+            }
+        }
+
+        q.isRankFeature shouldBe true
+        val rf = q.rankFeature()
+        rf.field() shouldBe "pagerank"
+        rf.saturation() shouldBe null
+        rf.log() shouldBe null
+        rf.linear() shouldBe null
+        rf.sigmoid() shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/RuleQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/RuleQueryTest.kt
@@ -1,0 +1,108 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.fulltext.matchQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class RuleQueryTest : FunSpec({
+
+    test("rule query - builds with organic fallback and match criteria") {
+        val criteria = mapOf(
+            "field_categories" to mapOf(
+                "country" to listOf("US", "KR")
+            ),
+            "metadata" to mapOf("channel" to "web")
+        )
+
+        val q = query {
+            ruleQueryDsl {
+                rulesetIds("rule-1", " rule-2 ")
+                organic {
+                    matchQuery {
+                        field = "title"
+                        query = "elastic"
+                    }
+                }
+                matchCriteria(criteria)
+                boost = 1.4f
+                _name = "rule-sample"
+            }
+        }
+
+        q.shouldNotBeNull()
+        q.isRuleQuery shouldBe true
+        val rule = q.ruleQuery()
+        rule.boost() shouldBe 1.4f
+        rule.queryName() shouldBe "rule-sample"
+        rule.rulesetId() shouldBe "rule-1"
+        rule.organic().isMatch shouldBe true
+        rule.matchCriteria().toString().contains("field_categories") shouldBe true
+    }
+
+    test("rule query - usable inside bool.must helper") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    ruleQuery {
+                        rulesetIds(listOf(" featured "))
+                        organic {
+                            matchQuery {
+                                field = "status"
+                                query = "active"
+                            }
+                        }
+                        matchCriteria(mapOf("tags" to listOf("kotlin")))
+                    }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        val mustQueries = q.bool().must()
+        mustQueries.size shouldBe 1
+        val nested = mustQueries.first()
+        nested.isRuleQuery shouldBe true
+        nested.ruleQuery().rulesetId() shouldBe "featured"
+    }
+
+    test("rule query - invalid definitions are skipped") {
+        val missingIds = queryOrNull {
+            ruleQueryDsl {
+                organic {
+                    matchQuery {
+                        field = "title"
+                        query = "dsl"
+                    }
+                }
+                matchCriteria(mapOf("category" to "tech"))
+            }
+        }
+        missingIds shouldBe null
+
+        val missingOrganic = queryOrNull {
+            ruleQueryDsl {
+                rulesetIds("rule-1")
+                matchCriteria(mapOf("category" to "tech"))
+            }
+        }
+        missingOrganic shouldBe null
+
+        val missingCriteria = queryOrNull {
+            ruleQueryDsl {
+                rulesetIds("rule-1")
+                organic {
+                    matchQuery {
+                        field = "title"
+                        query = "dsl"
+                    }
+                }
+            }
+        }
+        missingCriteria shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptQueryTest.kt
@@ -1,0 +1,105 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class ScriptQueryTest : FunSpec({
+
+    test("script query - inline script with params and metadata") {
+        val q = query {
+            scriptQuery {
+                inline(
+                    source = "doc['score'].value > params.threshold",
+                    lang = "painless",
+                    params = mapOf(
+                        "threshold" to 10,
+                        "flag" to true
+                    )
+                )
+                boost = 1.5f
+                _name = "inline-script"
+            }
+        }
+
+        q.shouldNotBeNull()
+        q.isScript shouldBe true
+        val scriptQuery = q.script()
+        scriptQuery.boost() shouldBe 1.5f
+        scriptQuery.queryName() shouldBe "inline-script"
+        val inline = scriptQuery.script().inline()
+        inline.source() shouldBe "doc['score'].value > params.threshold"
+        inline.lang() shouldBe "painless"
+        inline.params()?.size shouldBe 2
+        inline.params()?.containsKey("threshold") shouldBe true
+        inline.params()?.containsKey("flag") shouldBe true
+        q.toString().contains("\"inline-script\"") shouldBe true
+    }
+
+    test("script query - stored script uses id and params") {
+        val q = query {
+            scriptQuery {
+                stored(id = "stored-script-1", params = mapOf("userId" to "kimchy"))
+                boost = 0.7f
+            }
+        }
+
+        q.isScript shouldBe true
+        val scriptQuery = q.script()
+        scriptQuery.boost() shouldBe 0.7f
+        val stored = scriptQuery.script().stored()
+        stored.id() shouldBe "stored-script-1"
+        stored.params()?.containsKey("userId") shouldBe true
+    }
+
+    test("script query - usable inside bool helper") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    scriptQuery {
+                        inline(
+                            source = "doc['votes'].value >= params.min"
+                        )
+                        params("min" to 42)
+                    }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        val must = q.bool().must()
+        must.size shouldBe 1
+        val nested = must.first()
+        nested.isScript shouldBe true
+        nested.script().script().inline().source() shouldBe "doc['votes'].value >= params.min"
+    }
+
+    test("script query - invalid definitions are ignored") {
+        val missingContent = queryOrNull {
+            scriptQuery {
+                // only lang, no id/source
+                lang = "painless"
+            }
+        }
+        missingContent shouldBe null
+
+        val blankSource = queryOrNull {
+            scriptQuery {
+                source = "   "
+                params = mapOf("threshold" to 1)
+            }
+        }
+        blankSource shouldBe null
+
+        val blankId = queryOrNull {
+            scriptQuery {
+                stored(id = " ")
+            }
+        }
+        blankId shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptScoreQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/ScriptScoreQueryTest.kt
@@ -1,0 +1,104 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.matchAllDsl
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.termlevel.termQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class ScriptScoreQueryTest : FunSpec({
+
+    test("script_score query - inline script with default match_all") {
+        val q = query {
+            scriptScoreQuery {
+                inline(
+                    source = "Math.log(2 + doc['rating'].value) * params.factor",
+                    params = mapOf("factor" to 5)
+                )
+                boost = 2.0f
+                minScore = 0.5f
+                _name = "rating-score"
+            }
+        }
+
+        q.shouldNotBeNull()
+        q.isScriptScore shouldBe true
+        val scriptScore = q.scriptScore()
+        scriptScore.boost() shouldBe 2.0f
+        scriptScore.queryName() shouldBe "rating-score"
+        scriptScore.minScore() shouldBe 0.5f
+        scriptScore.query().isMatchAll shouldBe true
+        val inline = scriptScore.script().inline()
+        inline.source() shouldBe "Math.log(2 + doc['rating'].value) * params.factor"
+        inline.params()?.get("factor")?.toString() shouldBe "5"
+    }
+
+    test("script_score query - stored script with explicit inner query") {
+        val q = query {
+            scriptScoreQuery {
+                query {
+                    termQuery {
+                        field = "status"
+                        value = "active"
+                    }
+                }
+                stored(id = "score-by-status", params = mapOf("weight" to 3))
+                boost = 1.1f
+            }
+        }
+
+        q.isScriptScore shouldBe true
+        val scriptScore = q.scriptScore()
+        scriptScore.boost() shouldBe 1.1f
+        val stored = scriptScore.script().stored()
+        stored.id() shouldBe "score-by-status"
+        stored.params()?.get("weight")?.toString() shouldBe "3"
+        val inner = scriptScore.query()
+        inner.isTerm shouldBe true
+        inner.term().field() shouldBe "status"
+    }
+
+    test("script_score query - usable within bool.must via helper") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    scriptScoreQuery {
+                        query {
+                            matchAllDsl()
+                        }
+                        inline(source = "params.boost", params = mapOf("boost" to 2))
+                    }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        val mustQueries = q.bool().must()
+        mustQueries.size shouldBe 1
+        val nested = mustQueries.first()
+        nested.isScriptScore shouldBe true
+        nested.scriptScore().script().inline().source() shouldBe "params.boost"
+    }
+
+    test("script_score query - invalid definitions are skipped") {
+        val missingScript = queryOrNull {
+            scriptScoreQuery {
+                query {
+                    matchAllDsl()
+                }
+            }
+        }
+        missingScript shouldBe null
+
+        val blankStored = queryOrNull {
+            scriptScoreQuery {
+                stored(id = "   ")
+            }
+        }
+        blankStored shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/WeightedTokensQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/WeightedTokensQueryTest.kt
@@ -1,0 +1,90 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+class WeightedTokensQueryTest : FunSpec({
+
+    test("weighted tokens query - builds with tokens and pruning config") {
+        val q = query {
+            weightedTokensQuery {
+                field = "title.embedding"
+                tokens(
+                    "kotlin" to 1.0,
+                    "dsl" to 0.7,
+                    "search" to 0.4
+                )
+                pruningConfig {
+                    tokensFreqRatioThreshold = 3
+                    tokensWeightThreshold = 0.2f
+                    onlyScorePrunedTokens = true
+                }
+                boost = 1.1f
+                _name = "weighted-sample"
+            }
+        }
+
+        q.shouldNotBeNull()
+        q.isWeightedTokens shouldBe true
+        val weighted = q.weightedTokens()
+        weighted.boost() shouldBe 1.1f
+        weighted.queryName() shouldBe "weighted-sample"
+        weighted.field() shouldBe "title.embedding"
+        weighted.tokens()["kotlin"] shouldBe 1.0f
+        weighted.tokens().size shouldBe 3
+        val pruning = weighted.pruningConfig()
+        pruning.shouldNotBeNull()
+        pruning.tokensFreqRatioThreshold() shouldBe 3
+        pruning.tokensWeightThreshold() shouldBe 0.2f
+        pruning.onlyScorePrunedTokens() shouldBe true
+    }
+
+    test("weighted tokens query - usable inside bool.must helper") {
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    weightedTokensQuery {
+                        field = "title.embedding"
+                        tokens("elastic" to 1.5)
+                    }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        val must = q.bool().must()
+        must.size shouldBe 1
+        val nested = must.first()
+        nested.isWeightedTokens shouldBe true
+        nested.weightedTokens().tokens()["elastic"] shouldBe 1.5f
+    }
+
+    test("weighted tokens query - invalid inputs are skipped") {
+        val missingField = queryOrNull {
+            weightedTokensQuery {
+                tokens("kotlin" to 1.0)
+            }
+        }
+        missingField shouldBe null
+
+        val missingTokens = queryOrNull {
+            weightedTokensQuery {
+                field = "title.embedding"
+            }
+        }
+        missingTokens shouldBe null
+
+        val emptyTokens = queryOrNull {
+            weightedTokensQuery {
+                field = "title.embedding"
+                tokens(emptyMap())
+            }
+        }
+        emptyTokens shouldBe null
+    }
+})

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/WrapperQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/WrapperQueryTest.kt
@@ -1,0 +1,83 @@
+package com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.specialized
+
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.query
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.queryOrNull
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.compound.boolQuery
+import com.github.silbaram.elasticsearch.dynamic_query_dsl.clauses.mustQuery
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+class WrapperQueryTest : FunSpec({
+
+    test("wrapper query - raw json is encoded and metadata applied") {
+        val rawJson = """{"match":{"status":"active"}}"""
+        val q = query {
+            wrapperQuery {
+                rawJson(rawJson)
+                boost = 1.2f
+                _name = "raw-wrapper"
+            }
+        }
+
+        q.shouldNotBeNull()
+        q.isWrapper shouldBe true
+        val wrapper = q.wrapper()
+        wrapper.boost() shouldBe 1.2f
+        wrapper.queryName() shouldBe "raw-wrapper"
+        val decoded = String(Base64.getDecoder().decode(wrapper.query()), StandardCharsets.UTF_8)
+        decoded shouldBe rawJson
+    }
+
+    test("wrapper query - accepts pre-encoded base64 payload") {
+        val payload = "{\"term\":{\"user\":\"kimchy\"}}"
+        val encoded = Base64.getEncoder().encodeToString(payload.toByteArray(StandardCharsets.UTF_8))
+        val q = query {
+            wrapperQuery {
+                query = encoded
+            }
+        }
+
+        q.isWrapper shouldBe true
+        q.wrapper().query() shouldBe encoded
+    }
+
+    test("wrapper query - usable inside bool.must helper") {
+        val rawJson = """{"range":{"age":{"gte":30}}}"""
+        val q = query {
+            boolQuery {
+                mustQuery {
+                    wrapperQuery {
+                        rawJson(rawJson)
+                    }
+                }
+            }
+        }
+
+        q.isBool shouldBe true
+        val mustQueries = q.bool().must()
+        mustQueries.size shouldBe 1
+        val nested = mustQueries.first()
+        nested.isWrapper shouldBe true
+        val decoded = String(Base64.getDecoder().decode(nested.wrapper().query()), StandardCharsets.UTF_8)
+        decoded shouldBe rawJson
+    }
+
+    test("wrapper query - invalid definitions are skipped") {
+        val blankEncoded = queryOrNull {
+            wrapperQuery {
+                query = "  "
+            }
+        }
+        blankEncoded shouldBe null
+
+        val emptyRaw = queryOrNull {
+            wrapperQuery {
+                rawJson(" ")
+            }
+        }
+        emptyRaw shouldBe null
+    }
+})


### PR DESCRIPTION
This pull request introduces several significant enhancements and new query helpers to the Elasticsearch dynamic query DSL. The main focus is on expanding support for specialized queries, improving flexibility and correctness in query composition, and adding builder-style DSLs for advanced queries. Below are the most important changes grouped by theme.

### New Specialized Query DSLs

* Added builder-style DSLs and helpers for advanced queries in `SubQueryBuilders`, including `moreLikeThis`, `scriptQuery`, `scriptScoreQuery`, `wrapperQuery`, `pinnedQuery`, `ruleQuery`, `weightedTokensQuery`, `percolateQuery`, `knnQuery`, and `rankFeatureQuery`. This greatly expands the types of queries users can build fluently.
* Implemented a full builder-style DSL for `more_like_this` queries in `MoreLikeThisQuery.kt`, allowing flexible configuration of like/unlike texts and documents, fields, analyzers, and other parameters.
* Added a builder-style DSL for `knn` (nearest neighbor) queries in `KnnQuery.kt`, supporting vector search with optional filter queries and robust parameter validation.
* Added a builder-style DSL for `percolate` queries in `PercolateQuery.kt`, supporting single/multiple documents or index/id sources, with flexible routing and preference options.

### Query Composition & Correctness

* Updated `ConstantScoreQueryDsl` to ensure multiple filter queries are correctly grouped using the `filter` clause (not `must`), aligning with expected Elasticsearch semantics.
* Improved interval query DSLs (`IntervalsDsl.kt`) by tracking builder setters for each interval type, ensuring single interval rules are mapped directly (without unnecessary `any_of` wrapping), and supporting advanced interval composition. [[1]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R9) [[2]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R18) [[3]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R27) [[4]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R43-R52) [[5]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R65-R72) [[6]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R85-R92) [[7]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R108-R124) [[8]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R138-R147) [[9]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R160-R167) [[10]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R180-R187) [[11]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56R203-R213) [[12]](diffhunk://#diff-12cc6f9473123a94d8c3f88e8e129e55838cf9cfb3be8d6204c987a68dd57f56L157-L167)

### Internal Improvements

* Added imports for new specialized query DSLs in `SubQueryBuilders.kt` to enable the new helper methods.

These changes collectively make the query DSL much more powerful, easier to use, and better aligned with Elasticsearch's capabilities and semantics.