### PR TITLE
63 서브 쿼리 자연스럽게 querydsl과 비슷하게 수정

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -9,7 +9,7 @@
 - **안전한 생략 처리**: 불필요하거나 잘못된 입력을 자동으로 걸러냅니다.
 - **폭넓은 쿼리 지원**: 전문 검색, term-level, span, compound, script, wrapper, pinned, rule, weighted_tokens 등 다양한 Elasticsearch DSL을 커버합니다.
 - **Aggregation DSL**: terms/date histogram/composite/random sampler/time series 등 다양한 버킷 집계와 boxplot, cardinality, extended stats, geo bounds/centroid/line, matrix stats, MAD, percentiles, percentile ranks, rate, scripted metric, stats, string stats, t-test, top hits/metrics, weighted avg 등 메트릭 집계를 동일한 생략 규칙으로 구성합니다.
-- **재사용 가능한 헬퍼**: `SubQueryBuilders`로 bool 절 내부에서도 간단히 하위 쿼리를 누적할 수 있습니다. 이제 `queries[...]`나 `listOf` 없이도 동일 블록에서 순서대로 쿼리를 추가할 수 있습니다.
+- **재사용 가능한 헬퍼**: `SubQueryBuilders`로 bool 절 내부에서도 간단히 하위 쿼리를 누적할 수 있습니다. 서브 쿼리는 순차 호출, `queries[...]` 대괄호, `+query` 중 원하는 방식으로 추가할 수 있습니다.
 - **테스트 검증**: Kotest + JUnit 5 스펙이 패키지 구조와 동일하게 구성되어 있어 예제와 검증을 동시에 제공합니다.
 
 ## 요구 사항
@@ -50,7 +50,7 @@ val q: Query = query {
     }
 }
 
-// 최신 DSL은 `queries[...]` 없이도 중첩 bool 절을 자연스럽게 연결합니다.
+// 위 예시는 절 내부에서 순차적으로 헬퍼를 호출해 중첩 bool 쿼리를 구성하는 기본 패턴을 보여줍니다.
 ```
 
 ## DSL 개요
@@ -58,6 +58,26 @@ val q: Query = query {
 - 최상위는 `query { ... }` 또는 `queryOrNull { ... }` 를 사용합니다.
 - `mustQuery`, `filterQuery`, `shouldQuery`, `mustNotQuery` 등 절 전용 헬퍼로 서브 쿼리를 누적합니다.
 - `SubQueryBuilders`는 `termQuery`, `rangeQuery`, `matchQuery`, `scriptQuery`, `scriptScoreQuery`, `wrapperQuery`, `pinnedQuery` 등 자주 쓰는 빌더를 바로 노출합니다.
+
+#### 여러 하위 쿼리 누적하기
+- **순차 호출**: 절 블록 안에서 헬퍼를 연속 호출하면 유효한 쿼리가 자동으로 수집됩니다.
+- **대괄호 배치**: `queries[...]`를 사용해 여러 빌더 또는 미리 만들어둔 `Query?` 인스턴스를 한 번에 추가합니다.
+- **단항 플러스**: `+queryOrNull { ... }` 혹은 `+사전_생성_쿼리` 형태로 표현식 기반 누적도 가능합니다.
+
+```kotlin
+mustQuery {
+    termQuery { field = "status"; value = "active" }
+
+    queries[
+        {
+            termQuery { field = "tier"; value = "gold" }
+        },
+        queryOrNull { termQuery { field = "region"; value = regionIfAny } }
+    ]
+
+    +queryOrNull { matchQuery { field = "description"; query = keyword } }
+}
+```
 
 ### 자주 쓰는 쿼리 빌더
 - **Term/Range**: `termQuery`, `termsQuery`, `rangeQuery`, `existsQuery`, `matchAllDsl`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Type-safe Kotlin DSL for composing Elasticsearch queries. Builders omit null or 
 - **Safe omission** – Invalid or empty values get dropped automatically.
 - **Rich coverage** – Full-text, term-level, span, compound, and specialized queries (percolate, KNN, script, script_score, wrapper, pinned, rule, weighted_tokens, rank_feature, distance_feature).
 - **Aggregation DSL** – Compose bucket and metric aggregations (terms/date histogram/composite plus boxplot, cardinality, extended stats, geo bounds/centroid/line, matrix stats, MAD, percentiles, percentile ranks, rate, scripted metric, stats, string stats, t-test, top hits/metrics, weighted avg, etc.) with the same omission safeguards.
-- **Composable helpers** – `SubQueryBuilders` utilities let you stack clauses without repetitive `query { ... }` blocks.
+- **Composable helpers** – `SubQueryBuilders` utilities let you stack clauses without repetitive `query { ... }` blocks. 서브 쿼리는 `queries[...]` 나 `listOf` 없이도 동일 블록 안에서 순차적으로 누적할 수 있습니다.
 - **Battle-tested** – Kotest + JUnit 5 specs mirror the production package layout.
 
 ## Requirements
@@ -35,18 +35,29 @@ val q: Query = query {
     boolQuery {
         mustQuery {
             termQuery { field = "user.id"; value = "silbaram" }
+            boolQuery {
+                shouldQuery {
+                    termQuery { field = "tags"; value = "kotlin" }
+                    termQuery { field = "tags"; value = "dsl" }
+                }
+            }
         }
         filterQuery {
             rangeQuery { field = "age"; gte = 20; lt = 35 }
         }
         shouldQuery {
-            queries[
-                { termQuery { field = "tags"; value = "kotlin" } },
-                { termQuery { field = "tags"; value = "search" } }
-            ]
+            termQuery { field = "tags"; value = "search" }
+            boolQuery {
+                shouldQuery {
+                    termQuery { field = "interests"; value = "es" }
+                    termQuery { field = "interests"; value = "dsl" }
+                }
+            }
         }
     }
 }
+
+// 위 예시는 중첩 bool 쿼리를 `queries[...]` 없이 바로 쌓는 최신 DSL 사용법을 보여줍니다.
 ```
 
 ## DSL Overview

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Type-safe Kotlin DSL for composing Elasticsearch queries. Builders omit null or 
 - **Safe omission** – Invalid or empty values get dropped automatically.
 - **Rich coverage** – Full-text, term-level, span, compound, and specialized queries (percolate, KNN, script, script_score, wrapper, pinned, rule, weighted_tokens, rank_feature, distance_feature).
 - **Aggregation DSL** – Compose bucket and metric aggregations (terms/date histogram/composite plus boxplot, cardinality, extended stats, geo bounds/centroid/line, matrix stats, MAD, percentiles, percentile ranks, rate, scripted metric, stats, string stats, t-test, top hits/metrics, weighted avg, etc.) with the same omission safeguards.
-- **Composable helpers** – `SubQueryBuilders` utilities let you stack clauses without repetitive `query { ... }` blocks. 서브 쿼리는 `queries[...]` 나 `listOf` 없이도 동일 블록 안에서 순차적으로 누적할 수 있습니다.
+- **Composable helpers** – `SubQueryBuilders` utilities let you stack clauses without repetitive `query { ... }` blocks. Sub clauses can be added inline, batched with `queries[...]`, or fed prebuilt objects via `+query`.
 - **Battle-tested** – Kotest + JUnit 5 specs mirror the production package layout.
 
 ## Requirements
@@ -57,7 +57,7 @@ val q: Query = query {
     }
 }
 
-// 위 예시는 중첩 bool 쿼리를 `queries[...]` 없이 바로 쌓는 최신 DSL 사용법을 보여줍니다.
+// 위 예시는 절 안에서 순차적으로 헬퍼를 호출해 중첩 bool 쿼리를 구성하는 기본 패턴을 보여줍니다.
 ```
 
 ## DSL Overview
@@ -65,6 +65,26 @@ val q: Query = query {
 - Build top-level queries with `query { ... }` or `queryOrNull { ... }` (omits invalid content).
 - Use clause helpers (`mustQuery`, `filterQuery`, `shouldQuery`, `mustNotQuery`) to aggregate sub-queries.
 - `SubQueryBuilders` exposes inline helpers such as `termQuery`, `rangeQuery`, `matchQuery`, `scriptQuery`, `scriptScoreQuery`, `wrapperQuery`, `pinnedQuery`, etc.
+
+#### Collecting Multiple Sub-queries
+- **Sequential builders** – Just call helpers one after another; each valid `Query` is captured automatically.
+- **Bracket batching** – Use `queries[...]` to register several builders or pre-built `Query?` instances in one expression.
+- **Unary plus** – Apply `+queryOrNull { ... }` or `+prebuiltQuery` when you prefer expression-style accumulation.
+
+```kotlin
+mustQuery {
+    termQuery { field = "status"; value = "active" }
+
+    queries[
+        {
+            termQuery { field = "tier"; value = "gold" }
+        },
+        queryOrNull { termQuery { field = "region"; value = regionIfAny } }
+    ]
+
+    +queryOrNull { matchQuery { field = "description"; query = keyword } }
+}
+```
 
 ### Term & Full-text Helpers
 - `termQuery`, `termsQuery`, `rangeQuery`, `existsQuery`, `matchAllDsl`

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/FilterQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/FilterQuery.kt
@@ -6,7 +6,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * 람다를 사용하여 `filter` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
- * 단일 쿼리 또는 `queries[...]`를 사용한 여러 쿼리를 모두 지원합니다.
+ * 단일 쿼리를 순차적으로 추가하거나, 호환성을 위해 `queries[...]` 블록을 사용할 수 있습니다.
  */
 fun BoolQuery.Builder.filterQuery(
     fn: SubQueryBuilders.() -> Any?

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/FilterQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/FilterQuery.kt
@@ -6,7 +6,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * 람다를 사용하여 `filter` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
- * 단일 쿼리를 순차적으로 추가하거나, 호환성을 위해 `queries[...]` 블록을 사용할 수 있습니다.
+ * 단일 쿼리를 순차적으로 추가하거나 `queries[...]` 또는 `+query` 문법으로 등록할 수 있습니다.
  */
 fun BoolQuery.Builder.filterQuery(
     fn: SubQueryBuilders.() -> Any?

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/MustNotQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/MustNotQuery.kt
@@ -6,7 +6,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * 람다를 사용하여 `mustNot` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
- * 단일 쿼리 또는 `queries[...]`를 사용한 여러 쿼리를 모두 지원합니다.
+ * 단일 쿼리를 순차적으로 추가하거나, 호환성을 위해 `queries[...]` 블록을 사용할 수 있습니다.
  */
 fun BoolQuery.Builder.mustNotQuery(
     fn: SubQueryBuilders.() -> Any?

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/MustNotQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/MustNotQuery.kt
@@ -6,7 +6,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * 람다를 사용하여 `mustNot` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
- * 단일 쿼리를 순차적으로 추가하거나, 호환성을 위해 `queries[...]` 블록을 사용할 수 있습니다.
+ * 단일 쿼리를 순차적으로 추가하거나 `queries[...]` 또는 `+query` 문법으로 등록할 수 있습니다.
  */
 fun BoolQuery.Builder.mustNotQuery(
     fn: SubQueryBuilders.() -> Any?

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/MustQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/MustQuery.kt
@@ -6,7 +6,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * 람다를 사용하여 `must` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
- * 단일 쿼리를 순차적으로 추가하거나, 호환성을 위해 `queries[...]` 블록을 사용할 수 있습니다.
+ * 단일 쿼리를 순차적으로 추가하거나 `queries[...]` 또는 `+query` 문법으로 등록할 수 있습니다.
  */
 fun BoolQuery.Builder.mustQuery(
     fn: SubQueryBuilders.() -> Any?

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/MustQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/MustQuery.kt
@@ -6,7 +6,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * 람다를 사용하여 `must` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
- * 단일 쿼리 또는 `queries[...]`를 사용한 여러 쿼리를 모두 지원합니다.
+ * 단일 쿼리를 순차적으로 추가하거나, 호환성을 위해 `queries[...]` 블록을 사용할 수 있습니다.
  */
 fun BoolQuery.Builder.mustQuery(
     fn: SubQueryBuilders.() -> Any?

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/ShouldQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/ShouldQuery.kt
@@ -6,7 +6,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * 람다를 사용하여 `should` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
- * 단일 쿼리를 순차적으로 추가하거나, 호환성을 위해 `queries[...]` 블록을 사용할 수 있습니다.
+ * 단일 쿼리를 순차적으로 추가하거나 `queries[...]` 또는 `+query` 문법으로 등록할 수 있습니다.
  */
 fun BoolQuery.Builder.shouldQuery(
     fn: SubQueryBuilders.() -> Any?

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/ShouldQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/clauses/ShouldQuery.kt
@@ -6,7 +6,7 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.core.SubQueryBuilders
 
 /**
  * 람다를 사용하여 `should` 절에 쿼리를 추가하는 통합 DSL 함수입니다.
- * 단일 쿼리 또는 `queries[...]`를 사용한 여러 쿼리를 모두 지원합니다.
+ * 단일 쿼리를 순차적으로 추가하거나, 호환성을 위해 `queries[...]` 블록을 사용할 수 있습니다.
  */
 fun BoolQuery.Builder.shouldQuery(
     fn: SubQueryBuilders.() -> Any?

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/core/SubQueryBuilders.kt
@@ -17,7 +17,8 @@ import com.github.silbaram.elasticsearch.dynamic_query_dsl.queries.geo.*
 
 /**
  * 여러 clause 확장함수에서 재사용하는 Query 수집기.
- * - 기존 `queries[...]` 구문을 지원
+ * - 순차적으로 DSL 함수를 호출해도 자동으로 수집합니다.
+ * - 기존 `queries[...]` 구문도 하위 호환용으로 유지합니다.
  * - 단일 쿼리 추가용 addQuery / unaryPlus 지원
  */
 class SubQueryBuilders {
@@ -29,7 +30,11 @@ class SubQueryBuilders {
 
     // queries[ q1, q2 ] 를 처리
     operator fun get(vararg queries: Query?) {
-        this.collectedQueries.addAll(queries.filterNotNull())
+        queries.filterNotNull().forEach { query ->
+            if (!collectedQueries.contains(query)) {
+                collectedQueries.add(query)
+            }
+        }
     }
 
     // queries[ { builder... }, { builder... } ] 형태 지원
@@ -47,13 +52,17 @@ class SubQueryBuilders {
      * @param fn 중첩될 bool 쿼리를 설정하는 람다입니다.
      * @return 생성된 bool 쿼리를 담은 Query 객체를 반환합니다.
      */
-    fun boolQuery(fn: BoolQuery.Builder.() -> Unit): Query {
-        return Query.of { q ->
+    fun boolQuery(collect: Boolean = true, fn: BoolQuery.Builder.() -> Unit): Query {
+        val query = Query.of { q ->
             q.bool { b ->
                 b.fn()
                 b
             }
         }
+        if (collect) {
+            addQuery(query)
+        }
+        return query
     }
 
     // + 쿼리 문법을 선호한다면 아래를 사용:
@@ -72,6 +81,10 @@ class SubQueryBuilders {
     // --- Inline helpers to avoid explicit `query { ... }` inside clause blocks ---
     fun termQuery(fn: TermQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.termQuery(fn) })
+    }
+
+    fun termsQuery(fn: TermsQueryDsl.() -> Unit) {
+        addQuery(queryOrNull { this.termsQuery(fn) })
     }
 
     fun rangeQuery(fn: RangeQueryDsl.() -> Unit) {
@@ -152,6 +165,64 @@ class SubQueryBuilders {
 
     fun matchQuery(fn: MatchQueryDsl.() -> Unit) {
         addQuery(queryOrNull { this.matchQuery(fn) })
+    }
+
+    fun matchPhrase(
+        field: String,
+        query: String?,
+        analyzer: String? = null,
+        slop: Int? = null,
+        zeroTermsQuery: ZeroTermsQuery? = null,
+        boost: Float? = null,
+        _name: String? = null
+    ) {
+        addQuery(
+            queryOrNull {
+                this.matchPhrase(
+                    field = field,
+                    query = query,
+                    analyzer = analyzer,
+                    slop = slop,
+                    zeroTermsQuery = zeroTermsQuery,
+                    boost = boost,
+                    _name = _name
+                )
+            }
+        )
+    }
+
+    fun matchBoolPrefix(
+        field: String,
+        query: String?,
+        analyzer: String? = null,
+        operator: Operator? = null,
+        minimumShouldMatch: String? = null,
+        fuzziness: String? = null,
+        prefixLength: Int? = null,
+        maxExpansions: Int? = null,
+        fuzzyTranspositions: Boolean? = null,
+        fuzzyRewrite: String? = null,
+        boost: Float? = null,
+        _name: String? = null
+    ) {
+        addQuery(
+            queryOrNull {
+                this.matchBoolPrefix(
+                    field = field,
+                    query = query,
+                    analyzer = analyzer,
+                    operator = operator,
+                    minimumShouldMatch = minimumShouldMatch,
+                    fuzziness = fuzziness,
+                    prefixLength = prefixLength,
+                    maxExpansions = maxExpansions,
+                    fuzzyTranspositions = fuzzyTranspositions,
+                    fuzzyRewrite = fuzzyRewrite,
+                    boost = boost,
+                    _name = _name
+                )
+            }
+        )
     }
 
     fun spanTermQuery(fn: SpanTermQueryDsl.() -> Unit) {

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/BoostingQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/BoostingQuery.kt
@@ -10,8 +10,8 @@ class BoostingQueryDsl {
 
     fun positive(fn: SubQueryBuilders.() -> Any?) {
         val subQuery = SubQueryBuilders()
-        val result = fn(subQuery)
-        if (result is Query) {
+        val result = subQuery.fn()
+        if (subQuery.size() == 0 && result is Query) {
             subQuery.addQuery(result)
         }
         positiveQueries.addAll(subQuery)
@@ -19,8 +19,8 @@ class BoostingQueryDsl {
 
     fun negative(fn: SubQueryBuilders.() -> Any?) {
         val subQuery = SubQueryBuilders()
-        val result = fn(subQuery)
-        if (result is Query) {
+        val result = subQuery.fn()
+        if (subQuery.size() == 0 && result is Query) {
             subQuery.addQuery(result)
         }
         negativeQueries.addAll(subQuery)

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQuery.kt
@@ -11,7 +11,7 @@ class ConstantScoreQueryDsl {
     fun filterQuery(fn: SubQueryBuilders.() -> Any?) {
         val subQuery = SubQueryBuilders()
         val result = subQuery.fn()
-        if (result is Query) {
+        if (subQuery.size() == 0 && result is Query) {
             subQuery.addQuery(result)
         }
         filterQueries.addAll(subQuery)

--- a/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/KnnQuery.kt
+++ b/src/main/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/specialized/KnnQuery.kt
@@ -16,7 +16,9 @@ class KnnQueryDsl {
     fun filter(fn: SubQueryBuilders.() -> Any?) {
         val sub = SubQueryBuilders()
         val res = sub.fn()
-        if (res is Query) sub.addQuery(res)
+        if (sub.size() == 0 && res is Query) {
+            sub.addQuery(res)
+        }
         filterQueries.addAll(sub)
     }
 

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/ConstantScoreQueryTest.kt
@@ -96,10 +96,8 @@ class ConstantScoreQueryTest : FunSpec({
                 filterQuery {
                     constantScoreQuery {
                         filterQuery {
-                            queries[
-                                { termQuery { field = "brand"; value = "Samsung" } },
-                                { termQuery { field = "category"; value = "Electronics" } }
-                            ]
+                            termQuery { field = "brand"; value = "Samsung" }
+                            termQuery { field = "category"; value = "Electronics" }
                         }
                     }
                 }
@@ -119,13 +117,11 @@ class ConstantScoreQueryTest : FunSpec({
                 filterQuery {
                     boolQuery {
                         mustQuery {
-                                termQuery { field = "field1"; value = "value1" }
+                            termQuery { field = "field1"; value = "value1" }
                         }
                         shouldQuery {
-                            queries[
-                                { termQuery { field = "field2"; value = "value2" } },
-                                { termQuery { field = "field3"; value = "value3" } }
-                            ]
+                            termQuery { field = "field2"; value = "value2" }
+                            termQuery { field = "field3"; value = "value3" }
                         }.minimumShouldMatch("1")
                     }
                 }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/NestedBoolQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/compound/NestedBoolQueryTest.kt
@@ -16,10 +16,8 @@ class NestedBoolQueryTest : FunSpec({
                 mustQuery {
                     boolQuery {
                         shouldQuery {
-                            queries[
-                                { termQuery { field = "tags"; value = "kotlin" } },
-                                { termQuery { field = "tags"; value = "dsl" } }
-                            ]
+                            termQuery { field = "tags"; value = "kotlin" }
+                            termQuery { field = "tags"; value = "dsl" }
                         }
                     }
                 }
@@ -61,10 +59,8 @@ class NestedBoolQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        boolQuery { shouldQuery { termQuery { field = "field1"; value = "A" } } },
-                        boolQuery { mustQuery { termQuery { field = "field2"; value = "B" } } }
-                    ]
+                    boolQuery { shouldQuery { termQuery { field = "field1"; value = "A" } } }
+                    boolQuery { mustQuery { termQuery { field = "field2"; value = "B" } } }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/CombinedFieldsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/CombinedFieldsQueryTest.kt
@@ -29,12 +29,10 @@ class CombinedFieldsQueryTest : FunSpec({
         val q = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { combinedFields(query = "kotlin coroutine", fields = listOf("title", "desc")) },
-                        { combinedFields(query = null, fields = listOf("title")) },
-                        { combinedFields(query = "", fields = listOf("title")) },
-                        { combinedFields(query = "text", fields = emptyList()) }
-                    ]
+                    combinedFields(query = "kotlin coroutine", fields = listOf("title", "desc"))
+                    combinedFields(query = null, fields = listOf("title"))
+                    combinedFields(query = "", fields = listOf("title"))
+                    combinedFields(query = "text", fields = emptyList())
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/IntervalsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/IntervalsQueryTest.kt
@@ -10,7 +10,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 
 class IntervalsQueryTest : FunSpec({
-    
+
     test("기본 intervals match query가 생성되어야 함") {
         val query = query {
             intervals("content") { match("quick brown fox") }
@@ -86,10 +86,8 @@ class IntervalsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { intervals("content") { match("quick brown") } },
-                        { intervals("title") { prefix("fox") } }
-                    ]
+                    intervals("content") { match("quick brown") }
+                    intervals("title") { prefix("fox") }
                 }
             }
         }
@@ -133,12 +131,10 @@ class IntervalsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        query { intervals("title") { anyOf { match("elasticsearch") } } },
-                        query { intervals("content") { anyOf { prefix("search") } } },
-                        query { intervals("tags") { anyOf { wildcard("java*") } } },
-                        query { intervals("description") { anyOf { fuzzy("query", fuzziness = "1") } } }
-                    ]
+                    intervals("title") { anyOf { match("elasticsearch") } }
+                    intervals("content") { anyOf { prefix("search") } }
+                    intervals("tags") { anyOf { wildcard("java*") } }
+                    intervals("description") { anyOf { fuzzy("query", fuzziness = "1") } }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchBoolPrefixQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchBoolPrefixQueryTest.kt
@@ -30,10 +30,8 @@ class MatchBoolPrefixQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { matchBoolPrefix(field = "title", query = "quick brow") },
-                        { matchBoolPrefix(field = "desc", query = "kotlin dsl") }
-                    ]
+                    matchBoolPrefix(field = "title", query = "quick brow")
+                    matchBoolPrefix(field = "desc", query = "kotlin dsl")
                 }
             }
         }
@@ -49,11 +47,9 @@ class MatchBoolPrefixQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        queryOrNull { matchBoolPrefix(field = "a", query = null) },
-                        queryOrNull { matchBoolPrefix(field = "b", query = "") },
-                        query { matchBoolPrefix(field = "c", query = "hello w") }
-                    ]
+                    matchBoolPrefix(field = "a", query = null)
+                    matchBoolPrefix(field = "b", query = "")
+                    matchBoolPrefix(field = "c", query = "hello w")
                 }
             }
         }
@@ -68,9 +64,9 @@ class MatchBoolPrefixQueryTest : FunSpec({
     test("filter/mustNot/should 절에서도 동일하게 동작해야함") {
         val query = query {
             boolQuery {
-                filterQuery { queries[ { matchBoolPrefix(field = "a", query = "abc d") } ] }
-                mustNotQuery { queries[ { matchBoolPrefix(field = "b", query = "efg h") } ] }
-                shouldQuery { queries[ { matchBoolPrefix(field = "c", query = "ijk l") } ] }
+                filterQuery { matchBoolPrefix(field = "a", query = "abc d") }
+                mustNotQuery { matchBoolPrefix(field = "b", query = "efg h") }
+                shouldQuery { matchBoolPrefix(field = "c", query = "ijk l") }
             }
         }
 

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhrasePrefixQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhrasePrefixQueryTest.kt
@@ -28,10 +28,10 @@ class MatchPhrasePrefixQueryTest : FunSpec({
     test("must/filter/mustNot/should에서 생성/생략 동작") {
         val query = query {
             boolQuery {
-                mustQuery { queries[ { matchPhrasePrefix(field = "a", query = "quick bro") } ] }
-                filterQuery { queries[ { matchPhrasePrefix(field = "b", query = "fox ju") } ] }
-                mustNotQuery { queries[ { matchPhrasePrefix(field = "c", query = "over th") } ] }
-                shouldQuery { queries[ { matchPhrasePrefix(field = "d", query = "lazy do") } ] }
+                mustQuery { matchPhrasePrefix(field = "a", query = "quick bro") }
+                filterQuery { matchPhrasePrefix(field = "b", query = "fox ju") }
+                mustNotQuery { matchPhrasePrefix(field = "c", query = "over th") }
+                shouldQuery { matchPhrasePrefix(field = "d", query = "lazy do") }
             }
         }
 

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhraseQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchPhraseQueryTest.kt
@@ -17,11 +17,9 @@ class MatchPhraseQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        query { matchPhrase(field = "message", query = "this is a test") },
-                        queryOrNull { matchPhrase(field = "skip_null", query = null) },
-                        queryOrNull { matchPhrase(field = "skip_blank", query = "") }
-                    ]
+                    +query { matchPhrase(field = "message", query = "this is a test") }
+                    +queryOrNull { matchPhrase(field = "skip_null", query = null) }
+                    +queryOrNull { matchPhrase(field = "skip_blank", query = "") }
                 }
             }
         }
@@ -37,9 +35,9 @@ class MatchPhraseQueryTest : FunSpec({
     test("filter/mustNot/should 에서도 match_phrase 쿼리 동작") {
         val query = query {
             boolQuery {
-                filterQuery { queries[ { matchPhrase(field = "f", query = "alpha beta") } ] }
-                mustNotQuery { queries[ { matchPhrase(field = "mn", query = "gamma delta") } ] }
-                shouldQuery { queries[ { matchPhrase(field = "s", query = "quick brown fox") } ] }
+                filterQuery { +query { matchPhrase(field = "f", query = "alpha beta") } }
+                mustNotQuery { +query { matchPhrase(field = "mn", query = "gamma delta") } }
+                shouldQuery { +query { matchPhrase(field = "s", query = "quick brown fox") } }
             }
         }
 

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MatchQueryTest.kt
@@ -19,10 +19,8 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { matchQuery { field = "a"; query = "1111" } },
-                        { matchQuery { field = "b"; query = "2222" } }
-                    ]
+                    matchQuery { field = "a"; query = "1111" }
+                    matchQuery { field = "b"; query = "2222" }
                 }
             }
         }
@@ -35,15 +33,31 @@ class MatchQueryTest : FunSpec({
         mustQuery.filter { it.isMatch }.find { it.match().field() == "b" }?.match()?.query()?.stringValue() shouldBe "2222"
     }
 
+    test("mustQuery DSL은 queries 블록 없이도 여러 match 쿼리를 추가할 수 있어야 함") {
+        val query = query {
+            boolQuery {
+                mustQuery {
+                    matchQuery { field = "title"; query = "kotlin" }
+                    matchQuery { field = "body"; query = "dsl" }
+                }
+            }
+        }
+
+        val mustQuery = query.bool().must()
+
+        query.isBool shouldBe true
+        mustQuery.size shouldBe 2
+        mustQuery.any { it.match().field() == "title" && it.match().query().stringValue() == "kotlin" } shouldBe true
+        mustQuery.any { it.match().field() == "body" && it.match().query().stringValue() == "dsl" } shouldBe true
+    }
+
     test("must 쿼리에서 matchQuery에 query 값이 비었거나 null면 제외가 되어야함") {
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { matchQuery { field = "a"; query = null } },
-                        { matchQuery { field = "b"; query = "" } },
-                        { matchQuery { field = "c"; query = "3333" } }
-                    ]
+                    matchQuery { field = "a"; query = null }
+                    matchQuery { field = "b"; query = "" }
+                    matchQuery { field = "c"; query = "3333" }
                 }
             }
         }
@@ -61,10 +75,8 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { matchQuery { field = "a"; query = "" } },
-                        { matchQuery { field = "b"; query = null } }
-                    ]
+                    matchQuery { field = "a"; query = "" }
+                    matchQuery { field = "b"; query = null }
                 }
             }
         }
@@ -79,10 +91,8 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { matchQuery { field = "a"; query = "1111" } },
-                        { matchQuery { field = "b"; query = "2222" } }
-                    ]
+                    matchQuery { field = "a"; query = "1111" }
+                    matchQuery { field = "b"; query = "2222" }
                 }
             }
         }
@@ -99,11 +109,9 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { matchQuery { field = "a"; query = null } },
-                        { matchQuery { field = "b"; query = "" } },
-                        { matchQuery { field = "c"; query = "3333" } }
-                    ]
+                    matchQuery { field = "a"; query = null }
+                    matchQuery { field = "b"; query = "" }
+                    matchQuery { field = "c"; query = "3333" }
                 }
             }
         }
@@ -121,10 +129,8 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { matchQuery { field = "a"; query = "" } },
-                        { matchQuery { field = "b"; query = null } }
-                    ]
+                    matchQuery { field = "a"; query = "" }
+                    matchQuery { field = "b"; query = null }
                 }
             }
         }
@@ -140,10 +146,8 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustNotQuery {
-                    queries[
-                        query { matchQuery { field = "a"; query = "1111" } },
-                        query { matchQuery { field = "b"; query = "2222" } }
-                    ]
+                    matchQuery { field = "a"; query = "1111" }
+                    matchQuery { field = "b"; query = "2222" }
                 }
             }
         }
@@ -160,11 +164,9 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustNotQuery {
-                    queries[
-                        queryOrNull { matchQuery { field = "a"; query = null } },
-                        queryOrNull { matchQuery { field = "b"; query = "" } },
-                        query { matchQuery { field = "c"; query = "3333" } }
-                    ]
+                    matchQuery { field = "a"; query = null }
+                    matchQuery { field = "b"; query = "" }
+                    matchQuery { field = "c"; query = "3333" }
                 }
             }
         }
@@ -182,10 +184,8 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustNotQuery {
-                    queries[
-                        queryOrNull { matchQuery { field = "a"; query = "" } },
-                        queryOrNull { matchQuery { field = "b"; query = null } }
-                    ]
+                    matchQuery { field = "a"; query = "" }
+                    matchQuery { field = "b"; query = null }
                 }
             }
         }
@@ -199,10 +199,8 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        query { matchQuery { field = "a"; query = "1111" } },
-                        query { matchQuery { field = "b"; query = "2222" } }
-                    ]
+                    matchQuery { field = "a"; query = "1111" }
+                    matchQuery { field = "b"; query = "2222" }
                 }
             }
         }
@@ -219,11 +217,9 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        queryOrNull { matchQuery { field = "a"; query = null } },
-                        queryOrNull { matchQuery { field = "b"; query = "" } },
-                        query { matchQuery { field = "c"; query = "3333" } }
-                    ]
+                    matchQuery { field = "a"; query = null }
+                    matchQuery { field = "b"; query = "" }
+                    matchQuery { field = "c"; query = "3333" }
                 }
             }
         }
@@ -241,10 +237,8 @@ class MatchQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        queryOrNull { matchQuery { field = "a"; query = "" } },
-                        queryOrNull { matchQuery { field = "b"; query = null } }
-                    ]
+                    matchQuery { field = "a"; query = "" }
+                    matchQuery { field = "b"; query = null }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchPhraseQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchPhraseQueryTest.kt
@@ -32,12 +32,10 @@ class MultiMatchPhraseQueryTest : FunSpec({
         val q = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { multiMatchPhrase(query = "kotlin coroutine", fields = listOf("title", "desc")) },
-                        { multiMatchPhrase(query = null, fields = listOf("title")) },
-                        { multiMatchPhrase(query = "", fields = listOf("title")) },
-                        { multiMatchPhrase(query = "text", fields = emptyList()) }
-                    ]
+                    multiMatchPhrase(query = "kotlin coroutine", fields = listOf("title", "desc"))
+                    multiMatchPhrase(query = null, fields = listOf("title"))
+                    multiMatchPhrase(query = "", fields = listOf("title"))
+                    multiMatchPhrase(query = "text", fields = emptyList())
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/MultiMatchQueryTest.kt
@@ -36,12 +36,10 @@ class MultiMatchQueryTest : FunSpec({
         val q = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { multiMatch(query = "kotlin coroutine", fields = listOf("title", "desc")) },
-                        { multiMatch(query = null, fields = listOf("title")) },
-                        { multiMatch(query = "", fields = listOf("title")) },
-                        { multiMatch(query = "text", fields = emptyList()) }
-                    ]
+                    multiMatch(query = "kotlin coroutine", fields = listOf("title", "desc"))
+                    multiMatch(query = null, fields = listOf("title"))
+                    multiMatch(query = "", fields = listOf("title"))
+                    multiMatch(query = "text", fields = emptyList())
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/QueryStringQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/QueryStringQueryTest.kt
@@ -36,11 +36,9 @@ class QueryStringQueryTest : FunSpec({
         val q = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { queryString(query = "kotlin* AND \"structured query\"", fields = listOf("title", "body")) },
-                        { queryString(query = null) },
-                        { queryString(query = "") }
-                    ]
+                    queryString(query = "kotlin* AND \"structured query\"", fields = listOf("title", "body"))
+                    queryString(query = null)
+                    queryString(query = "")
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SimpleQueryStringQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/fulltext/SimpleQueryStringQueryTest.kt
@@ -52,11 +52,9 @@ class SimpleQueryStringQueryTest : FunSpec({
         val q = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { simpleQueryString(query = "kotlin* AND tags:(dsl | search)", fields = listOf("title", "tags")) },
-                        { simpleQueryString(query = null) },
-                        { simpleQueryString(query = "") }
-                    ]
+                    simpleQueryString(query = "kotlin* AND tags:(dsl | search)", fields = listOf("title", "tags"))
+                    simpleQueryString(query = null)
+                    simpleQueryString(query = "")
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/joining/HasChildQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/joining/HasChildQueryTest.kt
@@ -16,25 +16,23 @@ class HasChildQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { hasChildQuery {
-                            type = "reply"
-                            minChildren = 1
-                            maxChildren = 5
-                            scoreMode = ChildScoreMode.Sum
-                            ignoreUnmapped = true
-                            query {
-                                matchQuery {
-                                    field = "reply.text"
-                                    query = "ok"
-                                }
+                    hasChildQuery {
+                        type = "reply"
+                        minChildren = 1
+                        maxChildren = 5
+                        scoreMode = ChildScoreMode.Sum
+                        ignoreUnmapped = true
+                        query {
+                            matchQuery {
+                                field = "reply.text"
+                                query = "ok"
                             }
-                            innerHits {
-                                name("replies")
-                                size(3)
-                            }
-                        } }
-                    ]
+                        }
+                        innerHits {
+                            name("replies")
+                            size(3)
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/joining/HasParentQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/joining/HasParentQueryTest.kt
@@ -15,23 +15,21 @@ class HasParentQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { hasParentQuery {
-                            parentType = "question"
-                            score = true
-                            ignoreUnmapped = false
-                            query {
-                                matchQuery {
-                                    field = "question.title"
-                                    query = "search"
-                                }
+                    hasParentQuery {
+                        parentType = "question"
+                        score = true
+                        ignoreUnmapped = false
+                        query {
+                            matchQuery {
+                                field = "question.title"
+                                query = "search"
                             }
-                            innerHits {
-                                name("questions")
-                                size(1)
-                            }
-                        } }
-                    ]
+                        }
+                        innerHits {
+                            name("questions")
+                            size(1)
+                        }
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/joining/ParentIdQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/joining/ParentIdQueryTest.kt
@@ -14,15 +14,13 @@ class ParentIdQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { parentIdQuery {
-                            id = "parent-1"
-                            type = "reply"
-                            ignoreUnmapped = true
-                            boost = 0.8f
-                            _name = "parent-filter"
-                        } }
-                    ]
+                    parentIdQuery {
+                        id = "parent-1"
+                        type = "reply"
+                        ignoreUnmapped = true
+                        boost = 0.8f
+                        _name = "parent-filter"
+                    }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/ExistsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/ExistsQueryTest.kt
@@ -14,7 +14,7 @@ class ExistsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { existsQuery { field = "a" } }
+                    existsQuery { field = "a" }
                 }
             }
         }
@@ -29,10 +29,8 @@ class ExistsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { existsQuery { field = null } },
-                        { termQuery { field = "a"; value = "1111" } }
-                    ]
+                    existsQuery { field = null }
+                    termQuery { field = "a"; value = "1111" }
                 }
             }
         }
@@ -48,7 +46,7 @@ class ExistsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { existsQuery { field = "a"; boost = 2.0F } }
+                    existsQuery { field = "a"; boost = 2.0F }
                 }
             }
         }
@@ -64,7 +62,7 @@ class ExistsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { existsQuery { field = "a"; _name = "named" } }
+                    existsQuery { field = "a"; _name = "named" }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/FuzzyQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/FuzzyQueryTest.kt
@@ -12,9 +12,7 @@ class FuzzyQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { fuzzyQuery { field = "name"; value = "kim"; fuzziness = "AUTO"; prefixLength = 1; maxExpansions = 20; transpositions = true } }
-                    ]
+                    fuzzyQuery { field = "name"; value = "kim"; fuzziness = "AUTO"; prefixLength = 1; maxExpansions = 20; transpositions = true }
                 }
             }
         }
@@ -35,9 +33,7 @@ class FuzzyQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { fuzzyQuery { field = "age"; value = 33; fuzziness = "1" } }
-                    ]
+                    fuzzyQuery { field = "age"; value = 33; fuzziness = "1" }
                 }
             }
         }
@@ -53,10 +49,8 @@ class FuzzyQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { fuzzyQuery { field = ""; value = "kim" } },
-                        { fuzzyQuery { field = "name"; value = null } }
-                    ]
+                    fuzzyQuery { field = ""; value = "kim" }
+                    fuzzyQuery { field = "name"; value = null }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/IdsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/IdsQueryTest.kt
@@ -12,9 +12,7 @@ class IdsQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { idsQuery { values = listOf("1", "2", "3"); boost = 1.5f; _name = "ids-filter" } }
-                    ]
+                    idsQuery { values = listOf("1", "2", "3"); boost = 1.5f; _name = "ids-filter" }
                 }
             }
         }
@@ -33,9 +31,7 @@ class IdsQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { idsQuery { values = emptyList() } }
-                    ]
+                    idsQuery { values = emptyList() }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/MatchAllQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/MatchAllQueryTest.kt
@@ -12,7 +12,7 @@ class MatchAllQueryTest: FunSpec ({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { matchAllDsl() }
+                    matchAll()
                 }
             }
         }
@@ -33,7 +33,7 @@ class MatchAllQueryTest: FunSpec ({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { matchAllDsl { boost = 2.0F } }
+                    matchAll { boost = 2.0F }
                 }
             }
         }
@@ -50,7 +50,7 @@ class MatchAllQueryTest: FunSpec ({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { matchAllDsl { _name = "match_all_named" } }
+                    matchAll { _name = "match_all_named" }
                 }
             }
         }
@@ -67,7 +67,7 @@ class MatchAllQueryTest: FunSpec ({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { matchAllDsl { boost = 1.5F; _name = "boosted_match_all" } }
+                    matchAll { boost = 1.5F; _name = "boosted_match_all" }
                 }
             }
         }
@@ -85,10 +85,8 @@ class MatchAllQueryTest: FunSpec ({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        query { matchAllDsl { boost = 1.2F } },
-                        query { termQuery { field = "category"; value = "tech" } }
-                    ]
+                    matchAll { boost = 1.2F }
+                    termQuery { field = "category"; value = "tech" }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/PrefixQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/PrefixQueryTest.kt
@@ -12,9 +12,7 @@ class PrefixQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { prefixQuery { field = "title"; value = "pre"; caseInsensitive = true; boost = 2.1f } }
-                    ]
+                    prefixQuery { field = "title"; value = "pre"; caseInsensitive = true; boost = 2.1f }
                 }
             }
         }
@@ -35,10 +33,8 @@ class PrefixQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { prefixQuery { field = ""; value = "pre" } },
-                        { prefixQuery { field = "title"; value = null } }
-                    ]
+                    prefixQuery { field = ""; value = "pre" }
+                    prefixQuery { field = "title"; value = null }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/RangeQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/RangeQueryTest.kt
@@ -14,12 +14,10 @@ class RangeQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { rangeQuery { field = "a"; from = "1234" } },
-                        { rangeQuery { field = "a"; to = "5678" } },
-                        { rangeQuery { field = "b"; gt = 123; lt = 567 } },
-                        { rangeQuery { field = "c"; gte = 456; lte = 789 } }
-                    ]
+                    rangeQuery { field = "a"; from = "1234" }
+                    rangeQuery { field = "a"; to = "5678" }
+                    rangeQuery { field = "b"; gt = 123; lt = 567 }
+                    rangeQuery { field = "c"; gte = 456; lte = 789 }
                 }
             }
         }
@@ -45,7 +43,7 @@ class RangeQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { rangeQuery { field = "d"; gte = 10; lte = 20; boost = 3.0F } }
+                    rangeQuery { field = "d"; gte = 10; lte = 20; boost = 3.0F }
                 }
             }
         }
@@ -60,7 +58,7 @@ class RangeQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { rangeQuery { field = "d"; gte = 10; lte = 20; _name = "named" } }
+                    rangeQuery { field = "d"; gte = 10; lte = 20; _name = "named" }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/RegexpQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/RegexpQueryTest.kt
@@ -12,9 +12,7 @@ class RegexpQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        { regexpQuery { field = "keyword"; value = "ba.*"; flags = "INTERSECTION"; maxDeterminizedStates = 10000 } }
-                    ]
+                    regexpQuery { field = "keyword"; value = "ba.*"; flags = "INTERSECTION"; maxDeterminizedStates = 10000 }
                 }
             }
         }
@@ -33,10 +31,8 @@ class RegexpQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        { regexpQuery { field = null; value = "ba.*" } },
-                        { regexpQuery { field = "keyword"; value = "" } }
-                    ]
+                    regexpQuery { field = null; value = "ba.*" }
+                    regexpQuery { field = "keyword"; value = "" }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermQueryTest.kt
@@ -17,10 +17,8 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { termQuery { field = "a"; value = "1111" } },
-                        { termQuery { field = "b"; value = "2222" } }
-                    ]
+                    termQuery { field = "a"; value = "1111" }
+                    termQuery { field = "b"; value = "2222" }
                 }
             }
         }
@@ -37,11 +35,9 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { termQuery { field = "a"; value = null } },
-                        { termQuery { field = "b"; value = "" } },
-                        { termQuery { field = "c"; value = "3333" } }
-                    ]
+                    termQuery { field = "a"; value = null }
+                    termQuery { field = "b"; value = "" }
+                    termQuery { field = "c"; value = "3333" }
                 }
             }
         }
@@ -58,10 +54,8 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { termQuery { field = "a"; value = "" } },
-                        { termQuery { field = "b"; value = null } }
-                    ]
+                    termQuery { field = "a"; value = "" }
+                    termQuery { field = "b"; value = null }
                 }
             }
         }
@@ -75,10 +69,8 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { termQuery { field = "a"; value = "1111" } },
-                        { termQuery { field = "b"; value = "2222" } }
-                    ]
+                    termQuery { field = "a"; value = "1111" }
+                    termQuery { field = "b"; value = "2222" }
                 }
             }
         }
@@ -94,11 +86,9 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { termQuery { field = "a"; value = null } },
-                        { termQuery { field = "b"; value = "" } },
-                        { termQuery { field = "c"; value = "3333" } }
-                    ]
+                    termQuery { field = "a"; value = null }
+                    termQuery { field = "b"; value = "" }
+                    termQuery { field = "c"; value = "3333" }
                 }
             }
         }
@@ -115,10 +105,8 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { termQuery { field = "a"; value = "" } },
-                        { termQuery { field = "b"; value = null } }
-                    ]
+                    termQuery { field = "a"; value = "" }
+                    termQuery { field = "b"; value = null }
                 }
             }
         }
@@ -132,10 +120,8 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustNotQuery {
-                    queries[
-                        query { termQuery { field = "a"; value = "1111" } },
-                        query { termQuery { field = "b"; value = "2222" } }
-                    ]
+                    termQuery { field = "a"; value = "1111" }
+                    termQuery { field = "b"; value = "2222" }
                 }
             }
         }
@@ -151,11 +137,9 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustNotQuery {
-                    queries[
-                        queryOrNull { termQuery { field = "a"; value = null } },
-                        queryOrNull { termQuery { field = "b"; value = "" } },
-                        query { termQuery { field = "c"; value = "3333" } }
-                    ]
+                    termQuery { field = "a"; value = null }
+                    termQuery { field = "b"; value = "" }
+                    termQuery { field = "c"; value = "3333" }
                 }
             }
         }
@@ -172,10 +156,8 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustNotQuery {
-                    queries[
-                        queryOrNull { termQuery { field = "a"; value = "" } },
-                        queryOrNull { termQuery { field = "b"; value = null } }
-                    ]
+                    termQuery { field = "a"; value = "" }
+                    termQuery { field = "b"; value = null }
                 }
             }
         }
@@ -189,10 +171,8 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        query { termQuery { field = "a"; value = "1111" } },
-                        query { termQuery { field = "b"; value = "2222" } }
-                    ]
+                    termQuery { field = "a"; value = "1111" }
+                    termQuery { field = "b"; value = "2222" }
                 }
             }
         }
@@ -208,11 +188,9 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        queryOrNull { termQuery { field = "a"; value = null } },
-                        queryOrNull { termQuery { field = "b"; value = "" } },
-                        query { termQuery { field = "c"; value = "3333" } }
-                    ]
+                    termQuery { field = "a"; value = null }
+                    termQuery { field = "b"; value = "" }
+                    termQuery { field = "c"; value = "3333" }
                 }
             }
         }
@@ -229,10 +207,8 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        queryOrNull { termQuery { field = "a"; value = "" } },
-                        queryOrNull { termQuery { field = "b"; value = null } }
-                    ]
+                    termQuery { field = "a"; value = "" }
+                    termQuery { field = "b"; value = null }
                 }
             }
         }
@@ -246,7 +222,7 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { termQuery { field = "a"; value = "1111"; boost = 2.0F } }
+                    termQuery { field = "a"; value = "1111"; boost = 2.0F }
                 }
             }
         }
@@ -262,7 +238,7 @@ class TermQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { termQuery { field = "a"; value = "1111"; _name = "named" } }
+                    termQuery { field = "a"; value = "1111"; _name = "named" }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermsQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermsQueryTest.kt
@@ -18,10 +18,8 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { termsQuery { field = "a"; values = listOf("1111", "2222") } },
-                        { termsQuery { field = "b"; values = listOf("3333", "4444") } }
-                    ]
+                    termsQuery { field = "a"; values = listOf("1111", "2222") }
+                    termsQuery { field = "b"; values = listOf("3333", "4444") }
                 }
             }
         }
@@ -37,12 +35,10 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { termsQuery { field = "a"; values = null } },
-                        { termsQuery { field = "b"; values = emptyList() } },
-                        { termsQuery { field = "c"; values = listOf("1111", "2222") } },
-                        { termsQuery { field = "d"; values = listOf(null, "3333") } }
-                    ]
+                    termsQuery { field = "a"; values = null }
+                    termsQuery { field = "b"; values = emptyList() }
+                    termsQuery { field = "c"; values = listOf("1111", "2222") }
+                    termsQuery { field = "d"; values = listOf(null, "3333") }
                 }
             }
         }
@@ -60,10 +56,8 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { termsQuery { field = "a"; values = null } },
-                        { termsQuery { field = "b"; values = emptyList() } }
-                    ]
+                    termsQuery { field = "a"; values = null }
+                    termsQuery { field = "b"; values = emptyList() }
                 }
             }
         }
@@ -77,11 +71,9 @@ class TermsQueryTest : FunSpec({
     test("filter 쿼리에서 terms 쿼리 생성이 되어야함") {
         val query = query {
             boolQuery {
-                filterQuery{
-                    queries[
-                        { termsQuery { field = "a"; values = listOf("1111", "2222") } },
-                        { termsQuery { field = "b"; values = listOf("3333", "4444") } }
-                    ]
+                filterQuery {
+                    termsQuery { field = "a"; values = listOf("1111", "2222") }
+                    termsQuery { field = "b"; values = listOf("3333", "4444") }
                 }
             }
         }
@@ -97,12 +89,10 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { termsQuery { field = "a"; values = null } },
-                        { termsQuery { field = "b"; values = emptyList() } },
-                        { termsQuery { field = "c"; values = listOf("1111", "2222") } },
-                        { termsQuery { field = "d"; values = listOf(null, "3333") } }
-                    ]
+                    termsQuery { field = "a"; values = null }
+                    termsQuery { field = "b"; values = emptyList() }
+                    termsQuery { field = "c"; values = listOf("1111", "2222") }
+                    termsQuery { field = "d"; values = listOf(null, "3333") }
                 }
             }
         }
@@ -120,10 +110,8 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { termsQuery { field = "a"; values = null } },
-                        { termsQuery { field = "b"; values = emptyList() } }
-                    ]
+                    termsQuery { field = "a"; values = null }
+                    termsQuery { field = "b"; values = emptyList() }
                 }
             }
         }
@@ -138,10 +126,8 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustNotQuery {
-                    queries[
-                        { termsQuery { field = "a"; values = listOf("1111", "2222") } },
-                        { termsQuery { field = "b"; values = listOf("3333", "4444") } }
-                    ]
+                    termsQuery { field = "a"; values = listOf("1111", "2222") }
+                    termsQuery { field = "b"; values = listOf("3333", "4444") }
                 }
             }
         }
@@ -157,12 +143,10 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustNotQuery {
-                    queries[
-                        { termsQuery { field = "a"; values = null } },
-                        { termsQuery { field = "b"; values = emptyList() } },
-                        { termsQuery { field = "c"; values = listOf("1111", "2222") } },
-                        { termsQuery { field = "d"; values = listOf(null, "3333") } }
-                    ]
+                    termsQuery { field = "a"; values = null }
+                    termsQuery { field = "b"; values = emptyList() }
+                    termsQuery { field = "c"; values = listOf("1111", "2222") }
+                    termsQuery { field = "d"; values = listOf(null, "3333") }
                 }
             }
         }
@@ -180,10 +164,8 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { termsQuery { field = "a"; values = null } },
-                        { termsQuery { field = "b"; values = emptyList() } }
-                    ]
+                    termsQuery { field = "a"; values = null }
+                    termsQuery { field = "b"; values = emptyList() }
                 }
             }
         }
@@ -197,10 +179,8 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        query { termsQuery { field = "a"; values = listOf("1111", "2222") } },
-                        query { termsQuery { field = "b"; values = listOf("3333", "4444") } }
-                    ]
+                    termsQuery { field = "a"; values = listOf("1111", "2222") }
+                    termsQuery { field = "b"; values = listOf("3333", "4444") }
                 }
             }
         }
@@ -216,12 +196,10 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        queryOrNull { termsQuery { field = "a"; values = null } },
-                        queryOrNull { termsQuery { field = "b"; values = emptyList() } },
-                        query { termsQuery { field = "c"; values = listOf("1111", "2222") } },
-                        query { termsQuery { field = "d"; values = listOf(null, "3333") } }
-                    ]
+                    termsQuery { field = "a"; values = null }
+                    termsQuery { field = "b"; values = emptyList() }
+                    termsQuery { field = "c"; values = listOf("1111", "2222") }
+                    termsQuery { field = "d"; values = listOf(null, "3333") }
                 }
             }
         }
@@ -239,10 +217,8 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 shouldQuery {
-                    queries[
-                        queryOrNull { termsQuery { field = "a"; values = null } },
-                        queryOrNull { termsQuery { field = "b"; values = emptyList() } }
-                    ]
+                    termsQuery { field = "a"; values = null }
+                    termsQuery { field = "b"; values = emptyList() }
                 }
             }
         }
@@ -256,7 +232,7 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { termsQuery { field = "a"; values = listOf("1111", "2222"); boost = 2.5F } }
+                    termsQuery { field = "a"; values = listOf("1111", "2222"); boost = 2.5F }
                 }
             }
         }
@@ -272,7 +248,7 @@ class TermsQueryTest : FunSpec({
         val query = query {
             boolQuery {
                 mustQuery {
-                    query { termsQuery { field = "a"; values = listOf("1111", "2222"); _name = "named" } }
+                    termsQuery { field = "a"; values = listOf("1111", "2222"); _name = "named" }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermsSetQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/TermsSetQueryTest.kt
@@ -13,18 +13,16 @@ class TermsSetQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { termsSetQuery {
-                            field = "tags"
-                            terms = listOf("tech", "kotlin", "search")
-                            minimumShouldMatchField = "required_matches"
-                            minimumShouldMatchScript = Script.of { script ->
-                                script.inline { inlineScript ->
-                                    inlineScript.source("Math.min(params.num_terms, 2)")
-                                }
+                    termsSetQuery {
+                        field = "tags"
+                        terms = listOf("tech", "kotlin", "search")
+                        minimumShouldMatchField = "required_matches"
+                        minimumShouldMatchScript = Script.of { script ->
+                            script.inline { inlineScript ->
+                                inlineScript.source("Math.min(params.num_terms, 2)")
                             }
-                        } }
-                    ]
+                        }
+                    }
                 }
             }
         }
@@ -45,10 +43,8 @@ class TermsSetQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 mustQuery {
-                    queries[
-                        { termsSetQuery { field = null; terms = listOf("a") } },
-                        { termsSetQuery { field = "tags"; terms = emptyList() } }
-                    ]
+                    termsSetQuery { field = null; terms = listOf("a") }
+                    termsSetQuery { field = "tags"; terms = emptyList() }
                 }
             }
         }

--- a/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/WildcardQueryTest.kt
+++ b/src/test/kotlin/com/github/silbaram/elasticsearch/dynamic_query_dsl/queries/termlevel/WildcardQueryTest.kt
@@ -12,9 +12,7 @@ class WildcardQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { wildcardQuery { field = "title"; value = "abc*"; caseInsensitive = true } }
-                    ]
+                    wildcardQuery { field = "title"; value = "abc*"; caseInsensitive = true }
                 }
             }
         }
@@ -32,10 +30,8 @@ class WildcardQueryTest : FunSpec({
         val result = query {
             boolQuery {
                 filterQuery {
-                    queries[
-                        { wildcardQuery { field = ""; value = "abc*" } },
-                        { wildcardQuery { field = "title"; value = "" } }
-                    ]
+                    wildcardQuery { field = ""; value = "abc*" }
+                    wildcardQuery { field = "title"; value = "" }
                 }
             }
         }


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate artifact publishing for the project. The workflow supports publishing to both GitHub Packages and Maven Central, and can be triggered by pushes, pull requests, tags, or manually with a target selection.

**New workflow for artifact publishing:**

* Added `.github/workflows/publish.yml` to automate publishing artifacts to GitHub Packages and Maven Central, supporting triggers on push (main branch and tags), pull requests, and manual dispatch with target selection.
* Configured separate jobs for publishing to GitHub Packages and Central, each with appropriate authentication and environment setup using secrets and Gradle commands.
* Introduced workflow dispatch input to allow manual selection of the publishing target (`github` or `central`).